### PR TITLE
`tfcmt` and Node on Self-Hosted

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -82,10 +82,12 @@ runs:
           echo "actions_enabled=false" >> $GITHUB_OUTPUT
         fi
 
-    #- name: Update path
-    #  shell: bash
-    #  run: |
-    #    echo "/usr/local/bin" >> $GITHUB_PATH
+    # setup-tfcmt requires this PATH update when running on self-hosted (amazon linux)
+    # https://github.com/shmokmt/actions-setup-tfcmt/blob/main/action.yml#L11C1-L12C1
+    - name: Update path
+      shell: bash
+      run: |
+        echo "/usr/local/bin" >> $GITHUB_PATH
 
     - name: Setup tfcmt
       if: ${{ fromJSON(steps.settings.outputs.actions_enabled) }}

--- a/action.yml
+++ b/action.yml
@@ -54,7 +54,7 @@ runs:
       with:
         terraform_version: ${{ inputs.terraform_version }}
 
-    #- uses: actions/setup-node@v3
+    - uses: actions/setup-node@v3
 
     - uses: cloudposse/github-action-setup-atmos@1.0.2
       with:

--- a/action.yml
+++ b/action.yml
@@ -54,7 +54,7 @@ runs:
       with:
         terraform_version: ${{ inputs.terraform_version }}
 
-    - uses: actions/setup-node@v3
+    #- uses: actions/setup-node@v3
 
     - uses: cloudposse/github-action-setup-atmos@1.0.2
       with:

--- a/action.yml
+++ b/action.yml
@@ -55,6 +55,8 @@ runs:
         terraform_version: ${{ inputs.terraform_version }}
 
     - uses: actions/setup-node@v3
+      with:
+        node-version: 16
 
     - uses: cloudposse/github-action-setup-atmos@1.0.2
       with:

--- a/action.yml
+++ b/action.yml
@@ -80,12 +80,16 @@ runs:
           echo "actions_enabled=false" >> $GITHUB_OUTPUT
         fi
 
+    - name: Update path
+      shell: bash
+      run: |
+        echo "/usr/local/bin" >> $GITHUB_PATH
+
     - name: Setup tfcmt
       if: ${{ fromJSON(steps.settings.outputs.actions_enabled) }}
-      uses: shirakiya/setup-tfcmt@v1.1.0
-      # uses: shmokmt/actions-setup-tfcmt@v2
-      # with:
-      #   version: v4.4.1
+      uses: shmokmt/actions-setup-tfcmt@v2
+      with:
+        version: v4.4.1
     
     - name: Configure Plan AWS Credentials
       if: ${{ fromJSON(steps.settings.outputs.actions_enabled) }}

--- a/action.yml
+++ b/action.yml
@@ -79,10 +79,11 @@ runs:
         fi
 
     - name: Setup tfcmt
-      uses: shmokmt/actions-setup-tfcmt@v2
       if: ${{ fromJSON(steps.settings.outputs.actions_enabled) }}
-      with:
-        version: v4.4.1
+      uses: shirakiya/setup-tfcmt@v1.1.0
+      # uses: shmokmt/actions-setup-tfcmt@v2
+      # with:
+      #   version: v4.4.1
 
     - name: Configure Plan AWS Credentials
       if: ${{ fromJSON(steps.settings.outputs.actions_enabled) }}

--- a/action.yml
+++ b/action.yml
@@ -84,6 +84,9 @@ runs:
       # uses: shmokmt/actions-setup-tfcmt@v2
       # with:
       #   version: v4.4.1
+    
+    - uses: actions/setup-node@v3
+      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) }}
 
     - name: Configure Plan AWS Credentials
       if: ${{ fromJSON(steps.settings.outputs.actions_enabled) }}

--- a/action.yml
+++ b/action.yml
@@ -78,6 +78,9 @@ runs:
           echo "actions_enabled=false" >> $GITHUB_OUTPUT
         fi
 
+    - uses: actions/setup-node@v3
+      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) }}
+
     - name: Setup tfcmt
       if: ${{ fromJSON(steps.settings.outputs.actions_enabled) }}
       uses: shirakiya/setup-tfcmt@v1.1.0
@@ -85,9 +88,6 @@ runs:
       # with:
       #   version: v4.4.1
     
-    - uses: actions/setup-node@v3
-      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) }}
-
     - name: Configure Plan AWS Credentials
       if: ${{ fromJSON(steps.settings.outputs.actions_enabled) }}
       uses: aws-actions/configure-aws-credentials@v2.2.0

--- a/action.yml
+++ b/action.yml
@@ -54,6 +54,8 @@ runs:
       with:
         terraform_version: ${{ inputs.terraform_version }}
 
+    - uses: actions/setup-node@v3
+
     - uses: cloudposse/github-action-setup-atmos@1.0.2
       with:
         atmos-version: ${{ inputs.atmos-version }}
@@ -77,9 +79,6 @@ runs:
         else
           echo "actions_enabled=false" >> $GITHUB_OUTPUT
         fi
-
-    - uses: actions/setup-node@v3
-      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) }}
 
     - name: Setup tfcmt
       if: ${{ fromJSON(steps.settings.outputs.actions_enabled) }}

--- a/action.yml
+++ b/action.yml
@@ -105,6 +105,10 @@ runs:
       id: atmos-plan
       shell: bash
       run: |
+        echo $PATH
+        node --version
+        which node
+
         PLAN_FILE=$(echo "${{ inputs.stack }}-${{ inputs.component }}-${{github.sha}}.planfile" | sed 's#/#_#g') 
         PLAN_FILE_PATH=$(pwd)
         ATMOS_BASE_PATH=$GITHUB_WORKSPACE atmos terraform plan ${{ inputs.component }} \

--- a/action.yml
+++ b/action.yml
@@ -82,10 +82,10 @@ runs:
           echo "actions_enabled=false" >> $GITHUB_OUTPUT
         fi
 
-    - name: Update path
-      shell: bash
-      run: |
-        echo "/usr/local/bin" >> $GITHUB_PATH
+    #- name: Update path
+    #  shell: bash
+    #  run: |
+    #    echo "/usr/local/bin" >> $GITHUB_PATH
 
     - name: Setup tfcmt
       if: ${{ fromJSON(steps.settings.outputs.actions_enabled) }}
@@ -107,10 +107,6 @@ runs:
       id: atmos-plan
       shell: bash
       run: |
-        echo $PATH
-        node --version
-        which node
-
         PLAN_FILE=$(echo "${{ inputs.stack }}-${{ inputs.component }}-${{github.sha}}.planfile" | sed 's#/#_#g') 
         PLAN_FILE_PATH=$(pwd)
         ATMOS_BASE_PATH=$GITHUB_WORKSPACE atmos terraform plan ${{ inputs.component }} \

--- a/action.yml
+++ b/action.yml
@@ -58,7 +58,7 @@ runs:
       with:
         node-version: 16
 
-    - uses: cloudposse/github-action-setup-atmos@1.0.2
+    - uses: cloudposse/github-action-setup-atmos@v1
       with:
         atmos-version: ${{ inputs.atmos-version }}
         token: ${{ inputs.token }}


### PR DESCRIPTION
## what
- node and tfcmt installation debugging

## why
- When running on Self Hosted runners (amazon linux), we need to run these additional steps to setup Node and `tfcmt`

## references
- n/a