### PR TITLE
Support workflow_dispatch

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -140,7 +140,8 @@ runs:
 
     - name: Store Plan
       if: ${{ fromJSON(steps.settings.outputs.actions_enabled) }}
-      uses: cloudposse/github-action-terraform-plan-storage@1.7.0
+      #uses: cloudposse/github-action-terraform-plan-storage@v1
+      uses: cloudposse/github-action-terraform-plan-storage@workflow_dispatch_support
       id: store-plan
       with:
         action: storePlan
@@ -152,7 +153,8 @@ runs:
 
     - name: Store Lockfile
       if: ${{ fromJSON(steps.settings.outputs.actions_enabled) }}
-      uses: cloudposse/github-action-terraform-plan-storage@1.7.0
+      #uses: cloudposse/github-action-terraform-plan-storage@v1
+      uses: cloudposse/github-action-terraform-plan-storage@workflow_dispatch_support
       with:
         action: storePlan
         planPath: ${{ inputs.component-path}}/.terraform.lock.hcl

--- a/action.yml
+++ b/action.yml
@@ -228,7 +228,6 @@ runs:
           --config "${{ github.action_path }}/config/atmos_github_summary.yaml" \
           -owner "${{ github.repository_owner }}" \
           -repo "${{ github.event.repository.name }}" \
-          -pr "${{ github.event.number }}" \
           -var "target:${{ inputs.stack }}-${{ inputs.component }}" \
           -var "component:${{ inputs.component }}" \
           -var "stack:${{ inputs.stack }}" \

--- a/action.yml
+++ b/action.yml
@@ -140,8 +140,7 @@ runs:
 
     - name: Store Plan
       if: ${{ fromJSON(steps.settings.outputs.actions_enabled) }}
-      #uses: cloudposse/github-action-terraform-plan-storage@v1
-      uses: cloudposse/github-action-terraform-plan-storage@workflow_dispatch_support
+      uses: cloudposse/github-action-terraform-plan-storage@v1
       id: store-plan
       with:
         action: storePlan
@@ -153,8 +152,7 @@ runs:
 
     - name: Store Lockfile
       if: ${{ fromJSON(steps.settings.outputs.actions_enabled) }}
-      #uses: cloudposse/github-action-terraform-plan-storage@v1
-      uses: cloudposse/github-action-terraform-plan-storage@workflow_dispatch_support
+      uses: cloudposse/github-action-terraform-plan-storage@v1
       with:
         action: storePlan
         planPath: ${{ inputs.component-path}}/.terraform.lock.hcl

--- a/config/atmos_github_summary.yaml
+++ b/config/atmos_github_summary.yaml
@@ -2,7 +2,6 @@
 # https://suzuki-shunsuke.github.io/tfcmt/config
 embedded_var_names: []
 ci:
-  pr: []
   owner: []
   repo: []
   sha: []


### PR DESCRIPTION
## what
- Supporting triggering atmos workflows on workflow_dispatch

## why
- execute on demand
- `pr` arg breaks workflow_dispatch, but isn't used anyway. removed

## references
- DEV-1008
