### PR TITLE
Concurrency Limits

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -56,6 +56,10 @@ inputs:
       GHES, you can pass a personal access token for github.com if you are experiencing rate limiting.
     default: ${{ github.server_url == 'https://github.com' && github.token || '' }}
 
+# Limit concurrency for any plan for the same PR, component, and stack
+concurrency:
+  group: ${{ github.github.ref }}-${{ inputs.stack }}-${{ inputs.component }}
+
 runs:
   using: "composite"
   steps:

--- a/action.yml
+++ b/action.yml
@@ -56,12 +56,10 @@ inputs:
       GHES, you can pass a personal access token for github.com if you are experiencing rate limiting.
     default: ${{ github.server_url == 'https://github.com' && github.token || '' }}
 
-# Limit concurrency for any plan for the same trigger (typically PR or dispatch), component, and stack
-concurrency:
-  group: ${{ github.ref }}-${{ inputs.stack }}-${{ inputs.component }}
-
 runs:
   using: "composite"
+  concurrency:
+    group: ${{ github.ref }}-${{ inputs.stack }}-${{ inputs.component }}
   steps:
     - uses: actions/checkout@v3
 

--- a/action.yml
+++ b/action.yml
@@ -56,9 +56,9 @@ inputs:
       GHES, you can pass a personal access token for github.com if you are experiencing rate limiting.
     default: ${{ github.server_url == 'https://github.com' && github.token || '' }}
 
-# Limit concurrency for any plan for the same PR, component, and stack
+# Limit concurrency for any plan for the same trigger (typically PR or dispatch), component, and stack
 concurrency:
-  group: ${{ github.github.ref }}-${{ inputs.stack }}-${{ inputs.component }}
+  group: ${{ github.ref }}-${{ inputs.stack }}-${{ inputs.component }}
 
 runs:
   using: "composite"


### PR DESCRIPTION
## what
- Limit concurrency to grouping on `${{ github.github.ref }}-${{ inputs.stack }}-${{ inputs.component }}`

## why
- Any plan should wait for that last plan to finish for a specific trigger (PR or workflow), stack, and component

## references
- N/A
