### PR TITLE
Added `input.plan-id` and `output.has-changes`

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ this action. For more on setting up those components, see the `gitops` component
 | debug | Enable action debug mode. Default: 'false' | false | false |
 | enable-infracost | Whether to enable infracost summary. Requires secret `infracost-api-key` to be specified. Default: 'false | false | false |
 | infracost-api-key | Infracost API key | N/A | false |
+| plan-id | Suffix that will be used for plan file name to uniquely identify it. Default: github.sha | ${{ github.sha }} | true |
 | stack | The stack name for the given component. | N/A | true |
 | terraform-plan-role | The AWS role to be used to plan Terraform. | N/A | true |
 | terraform-state-bucket | The S3 Bucket where the planfiles are stored. | N/A | true |
@@ -146,6 +147,11 @@ this action. For more on setting up those components, see the `gitops` component
 | token | Used to pull node distributions for Atmos from Cloud Posse's GitHub repository. Since there's a default, this is typically not supplied by the user. When running this action on github.com, the default value is sufficient. When running on GHES, you can pass a personal access token for github.com if you are experiencing rate limiting. | ${{ github.server\_url == 'https://github.com' && github.token \|\| '' }} | false |
 
 
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| has-changes | Has Changes |
 <!-- markdownlint-restore -->
 
 

--- a/action.yml
+++ b/action.yml
@@ -167,7 +167,6 @@ runs:
       run: |
         echo ${{ steps.atmos-plan.outputs.has_changes }}
         echo ${{ fromJSON(steps.atmos-plan.outputs.has_changes) }}
-        echo ${{ "fromJSON(steps.atmos-plan.outputs.has_changes)" == "false" }}
         echo ${{ fromJSON(steps.atmos-plan.outputs.has_changes) == false }}
 
     - name: Configure State AWS Credentials

--- a/action.yml
+++ b/action.yml
@@ -151,11 +151,17 @@ runs:
       shell: bash
       run: |
         terraform show -json "${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}" > "${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json"
+        echo "here1"
         HAS_CHANGES=$(jq '.resource_changes[] | select(.change.actions[] != "no-op")' "${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json")
+        echo "here2"
 
         if [[ "$HAS_CHANGES" == "" ]]; then
+          echo "here3"
           echo "HAS_CHANGES=false" >> $GITHUB_ENV
+          echo "here4"
         fi
+
+        echo "here5"
 
     - name: Configure State AWS Credentials
       if: env.HAS_CHANGES == 'true'

--- a/action.yml
+++ b/action.yml
@@ -164,6 +164,8 @@ runs:
       run: |
         echo ${{ steps.atmos-plan.outputs.has_changes }}
         echo ${{ fromJSON(steps.atmos-plan.outputs.has_changes) }}
+        echo ${{ "fromJSON(steps.atmos-plan.outputs.has_changes)" == "false" }}
+        echo ${{ fromJSON(steps.atmos-plan.outputs.has_changes) == false }}
 
     - name: Configure State AWS Credentials
       if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}

--- a/action.yml
+++ b/action.yml
@@ -147,115 +147,115 @@ runs:
         EXIT_CODE=$?
         echo "EXIT_CODE: $EXIT_CODE"
         if [[ "$EXIT_CODE" != "0" ]]; then
-          echo "has_changes='true'" >> $GITHUB_OUTPUT
+          echo "has_changes=true" >> $GITHUB_OUTPUT
         else
-          echo "has_changes='false'" >> $GITHUB_OUTPUT
+          echo "has_changes=false" >> $GITHUB_OUTPUT
         fi
         echo "plan_file=$PLAN_FILE" >> $GITHUB_OUTPUT
         echo "plan_file_path=$PLAN_FILE_PATH" >> $GITHUB_OUTPUT
 
-    - name: Configure State AWS Credentials
-      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}
-      uses: aws-actions/configure-aws-credentials@v2.2.0
-      with:
-        aws-region: ${{ inputs.aws-region }}
-        role-to-assume: ${{ inputs.terraform-state-role }}
-        role-session-name: "atmos-terraform-state-gitops"
-        mask-aws-account-id: "no"
+    # - name: Configure State AWS Credentials
+    #   if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}
+    #   uses: aws-actions/configure-aws-credentials@v2.2.0
+    #   with:
+    #     aws-region: ${{ inputs.aws-region }}
+    #     role-to-assume: ${{ inputs.terraform-state-role }}
+    #     role-session-name: "atmos-terraform-state-gitops"
+    #     mask-aws-account-id: "no"
 
-    - name: Store Plan
-      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}
-      uses: cloudposse/github-action-terraform-plan-storage@v1
-      id: store-plan
-      with:
-        action: storePlan
-        planPath: ${{ steps.atmos-plan.outputs.plan_file }}
-        component: ${{ inputs.component }}
-        stack: ${{ inputs.stack }}
-        tableName: ${{ inputs.terraform-state-table }}
-        bucketName: ${{ inputs.terraform-state-bucket }}
+    # - name: Store Plan
+    #   if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}
+    #   uses: cloudposse/github-action-terraform-plan-storage@v1
+    #   id: store-plan
+    #   with:
+    #     action: storePlan
+    #     planPath: ${{ steps.atmos-plan.outputs.plan_file }}
+    #     component: ${{ inputs.component }}
+    #     stack: ${{ inputs.stack }}
+    #     tableName: ${{ inputs.terraform-state-table }}
+    #     bucketName: ${{ inputs.terraform-state-bucket }}
 
-    - name: Store Lockfile
-      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}
-      uses: cloudposse/github-action-terraform-plan-storage@v1
-      with:
-        action: storePlan
-        planPath: ${{ inputs.component-path}}/.terraform.lock.hcl
-        component: ${{ inputs.component }}
-        stack: "${{ inputs.stack }}-lockfile"
-        tableName: ${{ inputs.terraform-state-table }}
-        bucketName: ${{ inputs.terraform-state-bucket }}
+    # - name: Store Lockfile
+    #   if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}
+    #   uses: cloudposse/github-action-terraform-plan-storage@v1
+    #   with:
+    #     action: storePlan
+    #     planPath: ${{ inputs.component-path}}/.terraform.lock.hcl
+    #     component: ${{ inputs.component }}
+    #     stack: "${{ inputs.stack }}-lockfile"
+    #     tableName: ${{ inputs.terraform-state-table }}
+    #     bucketName: ${{ inputs.terraform-state-bucket }}
 
-    - name: Setup Infracost
-      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
-      uses: infracost/actions/setup@v2
-      with:
-        api-key: ${{ inputs.infracost-api-key }}
+    # - name: Setup Infracost
+    #   if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
+    #   uses: infracost/actions/setup@v2
+    #   with:
+    #     api-key: ${{ inputs.infracost-api-key }}
 
-    - name: Generate Infracost diff
-      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
-      shell: bash
-      run: |
-        PLAN_FILE_JSON="${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json"
+    # - name: Generate Infracost diff
+    #   if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
+    #   shell: bash
+    #   run: |
+    #     PLAN_FILE_JSON="${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json"
 
-        cd ${{ inputs.component-path }}
-        terraform show -json $PLAN_FILE > $PLAN_FILE_JSON
+    #     cd ${{ inputs.component-path }}
+    #     terraform show -json $PLAN_FILE > $PLAN_FILE_JSON
 
-        infracost diff \
-          --path=$PLAN_FILE_JSON \
-          --format=diff \
-          --project-name ${{ inputs.stack }}-${{ inputs.component }} \
-          --out-file=/tmp/infracost.txt
-        infracost diff \
-          --path=$PLAN_FILE_JSON \
-          --format=json \
-          --project-name ${{ inputs.stack }}-${{ inputs.component }} \
-          --out-file=/tmp/infracost.json
+    #     infracost diff \
+    #       --path=$PLAN_FILE_JSON \
+    #       --format=diff \
+    #       --project-name ${{ inputs.stack }}-${{ inputs.component }} \
+    #       --out-file=/tmp/infracost.txt
+    #     infracost diff \
+    #       --path=$PLAN_FILE_JSON \
+    #       --format=json \
+    #       --project-name ${{ inputs.stack }}-${{ inputs.component }} \
+    #       --out-file=/tmp/infracost.json
 
-    - if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) && fromJSON(inputs.debug) }}
-      shell: bash
-      run: |
-        cat ${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json
-        cat /tmp/infracost.txt
-        cat /tmp/infracost.json
+    # - if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) && fromJSON(inputs.debug) }}
+    #   shell: bash
+    #   run: |
+    #     cat ${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json
+    #     cat /tmp/infracost.txt
+    #     cat /tmp/infracost.json
 
-    - name: Set infracost variables
-      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
-      id: infracost-diff
-      shell: bash
-      run: |
-        if [[ "${{ inputs.enable-infracost }}" == "true" ]]; then
-          INFRACOST_DIFF_TOTAL_MONTHLY_COST=$(cat /tmp/infracost.json | jq --raw-output .diffTotalMonthlyCost)
-          INFRACOST_DETAILS_DIFF_BREAKDOWN="$(cat /tmp/infracost.txt | base64 --wrap 0)"
-        else
-          INFRACOST_DIFF_TOTAL_MONTHLY_COST="0"
-          INFRACOST_DETAILS_DIFF_BREAKDOWN=""
-        fi
+    # - name: Set infracost variables
+    #   if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
+    #   id: infracost-diff
+    #   shell: bash
+    #   run: |
+    #     if [[ "${{ inputs.enable-infracost }}" == "true" ]]; then
+    #       INFRACOST_DIFF_TOTAL_MONTHLY_COST=$(cat /tmp/infracost.json | jq --raw-output .diffTotalMonthlyCost)
+    #       INFRACOST_DETAILS_DIFF_BREAKDOWN="$(cat /tmp/infracost.txt | base64 --wrap 0)"
+    #     else
+    #       INFRACOST_DIFF_TOTAL_MONTHLY_COST="0"
+    #       INFRACOST_DETAILS_DIFF_BREAKDOWN=""
+    #     fi
 
-        echo "infracost_details_diff_breakdown=$INFRACOST_DETAILS_DIFF_BREAKDOWN" >> "$GITHUB_OUTPUT"
-        echo "infracost_diff_total_monthly_cost=$INFRACOST_DIFF_TOTAL_MONTHLY_COST" >> "$GITHUB_OUTPUT"
+    #     echo "infracost_details_diff_breakdown=$INFRACOST_DETAILS_DIFF_BREAKDOWN" >> "$GITHUB_OUTPUT"
+    #     echo "infracost_diff_total_monthly_cost=$INFRACOST_DIFF_TOTAL_MONTHLY_COST" >> "$GITHUB_OUTPUT"
 
-    - name: Post Plan
-      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
-      id: post-plan
-      shell: bash
-      run: |
-        if [[ "${{ inputs.debug }}" == "true" ]]; then
-          LOG_LEVEL="DEBUG"
-        else
-          LOG_LEVEL="INFO"
-        fi
-        cd ${{ inputs.component-path }}
-        tfcmt \
-          --config "${{ github.action_path }}/config/atmos_github_summary.yaml" \
-          -owner "${{ github.repository_owner }}" \
-          -repo "${{ github.event.repository.name }}" \
-          -var "target:${{ inputs.stack }}-${{ inputs.component }}" \
-          -var "component:${{ inputs.component }}" \
-          -var "stack:${{ inputs.stack }}" \
-          -var "job:${{ github.job }}" \
-          -var "infracost_details_diff_breakdown:${{ steps.infracost-diff.outputs.infracost_details_diff_breakdown }}" \
-          -var "infracost_total_monthly_cost:${{ steps.infracost-diff.outputs.infracost_diff_total_monthly_cost }}" \
-          --output $GITHUB_STEP_SUMMARY \
-          --log-level $LOG_LEVEL \
-          plan -- terraform show ${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}
+    # - name: Post Plan
+    #   if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
+    #   id: post-plan
+    #   shell: bash
+    #   run: |
+    #     if [[ "${{ inputs.debug }}" == "true" ]]; then
+    #       LOG_LEVEL="DEBUG"
+    #     else
+    #       LOG_LEVEL="INFO"
+    #     fi
+    #     cd ${{ inputs.component-path }}
+    #     tfcmt \
+    #       --config "${{ github.action_path }}/config/atmos_github_summary.yaml" \
+    #       -owner "${{ github.repository_owner }}" \
+    #       -repo "${{ github.event.repository.name }}" \
+    #       -var "target:${{ inputs.stack }}-${{ inputs.component }}" \
+    #       -var "component:${{ inputs.component }}" \
+    #       -var "stack:${{ inputs.stack }}" \
+    #       -var "job:${{ github.job }}" \
+    #       -var "infracost_details_diff_breakdown:${{ steps.infracost-diff.outputs.infracost_details_diff_breakdown }}" \
+    #       -var "infracost_total_monthly_cost:${{ steps.infracost-diff.outputs.infracost_diff_total_monthly_cost }}" \
+    #       --output $GITHUB_STEP_SUMMARY \
+    #       --log-level $LOG_LEVEL \
+    #       plan -- terraform show ${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}

--- a/action.yml
+++ b/action.yml
@@ -153,8 +153,8 @@ runs:
         ls -l
         pwd
 
-        PLAN_FILE="${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}"
-        PLAN_FILE_JSON="${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json"
+        PLAN_FILE="${{ steps.atmos-plan.outputs.plan_file }}"
+        PLAN_FILE_JSON="${{ steps.atmos-plan.outputs.plan_file }}.json"
 
         echo $PLAN_FILE
         echo $PLAN_FILE_JSON

--- a/action.yml
+++ b/action.yml
@@ -132,7 +132,7 @@ runs:
       shell: bash
       run: |
         SUFFIX="${{ github.sha }}"
-        if [ "$variable" != "" ]; then
+        if [ "${{ inputs.plan-file-suffix }}" != "" ]; then
           SUFFIX="${{ inputs.plan-file-suffix }}"
         fi
 

--- a/action.yml
+++ b/action.yml
@@ -66,6 +66,9 @@ outputs:
   plan-file:
     description: Plan File
     value: ${{ steps.atmos-plan.outputs.plan_file }}
+  has-changes:
+    description: Has Changes
+    value: ${{ steps.atmos-plan.outputs.has_changes }}
 
 runs:
   using: "composite"

--- a/action.yml
+++ b/action.yml
@@ -156,10 +156,15 @@ runs:
         cd ${{ inputs.component-path }}
         terraform show -json $PLAN_FILE > $PLAN_FILE_JSON
 
-        cat $PLAN_FILE_JSON
+        json_output=$(terraform show -json $PLAN_FILE)
+        change_summary=$(echo "$json_output" | jq '.resource_changes | map(select(.change.actions | length > 0)) | length')
 
-        jq --version
-        jq . $PLAN_FILE_JSON
+        if [[ $change_summary -gt 0 ]]; then
+            echo "There are changes."
+        else
+            echo "No changes."
+        fi
+
 
         # HAS_CHANGES=$(jq '.resource_changes[] | select(.change.actions[] != "no-op")' $PLAN_FILE_JSON)
         # echo "HAS_CHANGES=$HAS_CHANGES"

--- a/action.yml
+++ b/action.yml
@@ -150,20 +150,20 @@ runs:
       id: plan-state
       shell: bash
       run: |
-        ls -l
-        pwd
+        set -ex
 
-        PLAN_FILE="${{ steps.atmos-plan.outputs.plan_file }}"
-        PLAN_FILE_JSON="${{ steps.atmos-plan.outputs.plan_file }}.json"
+        PLAN_FILE="${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}"
+        PLAN_FILE_JSON="${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json"
 
         echo $PLAN_FILE
         echo $PLAN_FILE_JSON
 
+        cd ${{ inputs.component-path }}
         terraform show -json $PLAN_FILE > $PLAN_FILE_JSON
 
         cat $PLAN_FILE_JSON | jq .
 
-        HAS_CHANGES=$(jq '.resource_changes[] | select(.change.actions[] != "no-op")' "${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json")
+        HAS_CHANGES=$(jq '.resource_changes[] | select(.change.actions[] != "no-op")' "$PLAN_FILE_JSON")
         echo "HAS_CHANGES=$HAS_CHANGES"
 
         if [[ "$HAS_CHANGES" == "" ]]; then

--- a/action.yml
+++ b/action.yml
@@ -154,6 +154,11 @@ runs:
         echo "plan_file=$PLAN_FILE" >> $GITHUB_OUTPUT
         echo "plan_file_path=$PLAN_FILE_PATH" >> $GITHUB_OUTPUT
 
+    - shell: bash
+      run: |
+        echo "has_changes: ${{ steps.atmos-plan.outputs.has_changes }}"
+        echo "has_changes_json: ${{ fromJSON(steps.atmos-plan.outputs.has_changes) }}"
+
     - name: Configure State AWS Credentials
       if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}
       uses: aws-actions/configure-aws-credentials@v2.2.0
@@ -175,16 +180,17 @@ runs:
         tableName: ${{ inputs.terraform-state-table }}
         bucketName: ${{ inputs.terraform-state-bucket }}
 
-    - name: Store Lockfile
-      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}
-      uses: cloudposse/github-action-terraform-plan-storage@v1
-      with:
-        action: storePlan
-        planPath: ${{ inputs.component-path}}/.terraform.lock.hcl
-        component: ${{ inputs.component }}
-        stack: "${{ inputs.stack }}-lockfile"
-        tableName: ${{ inputs.terraform-state-table }}
-        bucketName: ${{ inputs.terraform-state-bucket }}
+    # - name: Store Lockfile
+    #   if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}
+    #   uses: cloudposse/github-action-terraform-plan-storage@v1
+    #   with:
+    #     action: storePlan
+    #     planPath: ${{ inputs.component-path}}/.terraform.lock.hcl
+    #     component: ${{ inputs.component }}
+    #     stack: "${{ inputs.stack }}-lockfile"
+    #     tableName: ${{ inputs.terraform-state-table }}
+    #     bucketName: ${{ inputs.terraform-state-bucket }}
+
 
     # - name: Setup Infracost
     #   if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}

--- a/action.yml
+++ b/action.yml
@@ -141,37 +141,13 @@ runs:
         ATMOS_BASE_PATH=$GITHUB_WORKSPACE atmos terraform plan ${{ inputs.component }} \
           --stack ${{ inputs.stack }} \
           -out=$PLAN_FILE_PATH/$PLAN_FILE \
-          -input=false
+          -input=false -detailed-exitcode
+        EXIT_CODE=$?
+        if [[ "$EXIT_CODE" != "0" ]]; then
+          echo "HAS_CHANGES=false" >> $GITHUB_ENV
+        fi
         echo "plan_file=$PLAN_FILE" >> $GITHUB_OUTPUT
         echo "plan_file_path=$PLAN_FILE_PATH" >> $GITHUB_OUTPUT
-
-    - name: Plan Has Changes
-      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) }}
-      id: plan-state
-      shell: bash
-      run: |
-        PLAN_FILE="${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}"
-        PLAN_FILE_JSON="${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json"
-
-        cd ${{ inputs.component-path }}
-        terraform show -json $PLAN_FILE > $PLAN_FILE_JSON
-
-        json_output=$(terraform show -json $PLAN_FILE)
-        change_summary=$(echo "$json_output" | jq '.resource_changes | map(select(.change.actions | length > 0)) | length')
-
-        if [[ $change_summary -gt 0 ]]; then
-            echo "There are changes."
-        else
-            echo "No changes."
-        fi
-
-
-        # HAS_CHANGES=$(jq '.resource_changes[] | select(.change.actions[] != "no-op")' $PLAN_FILE_JSON)
-        # echo "HAS_CHANGES=$HAS_CHANGES"
-
-        # if [[ "$HAS_CHANGES" == "" ]]; then
-        #   echo "HAS_CHANGES=false" >> $GITHUB_ENV
-        # fi
 
     - name: Configure State AWS Credentials
       if: env.HAS_CHANGES == 'true'

--- a/action.yml
+++ b/action.yml
@@ -87,7 +87,7 @@ runs:
       with:
         atmos-version: ${{ inputs.atmos-version }}
         token: ${{ inputs.token }}
-        install-wrapper: true
+        install-wrapper: false
 
     - name: Filter Atmos Settings Value
       uses: cloudposse/github-action-atmos-get-setting@v0

--- a/action.yml
+++ b/action.yml
@@ -159,38 +159,37 @@ runs:
         echo "has_changes: ${{ steps.atmos-plan.outputs.has_changes }}"
         echo "has_changes_json: ${{ fromJSON(steps.atmos-plan.outputs.has_changes) }}"
 
-    # - name: Configure State AWS Credentials
-    #   if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}
-    #   uses: aws-actions/configure-aws-credentials@v2.2.0
-    #   with:
-    #     aws-region: ${{ inputs.aws-region }}
-    #     role-to-assume: ${{ inputs.terraform-state-role }}
-    #     role-session-name: "atmos-terraform-state-gitops"
-    #     mask-aws-account-id: "no"
+    - name: Configure State AWS Credentials
+      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}
+      uses: aws-actions/configure-aws-credentials@v2.2.0
+      with:
+        aws-region: ${{ inputs.aws-region }}
+        role-to-assume: ${{ inputs.terraform-state-role }}
+        role-session-name: "atmos-terraform-state-gitops"
+        mask-aws-account-id: "no"
 
-    # - name: Store Plan
-    #   if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}
-    #   uses: cloudposse/github-action-terraform-plan-storage@v1
-    #   id: store-plan
-    #   with:
-    #     action: storePlan
-    #     planPath: ${{ steps.atmos-plan.outputs.plan_file }}
-    #     component: ${{ inputs.component }}
-    #     stack: ${{ inputs.stack }}
-    #     tableName: ${{ inputs.terraform-state-table }}
-    #     bucketName: ${{ inputs.terraform-state-bucket }}
+    - name: Store Plan
+      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}
+      uses: cloudposse/github-action-terraform-plan-storage@v1
+      id: store-plan
+      with:
+        action: storePlan
+        planPath: ${{ steps.atmos-plan.outputs.plan_file }}
+        component: ${{ inputs.component }}
+        stack: ${{ inputs.stack }}
+        tableName: ${{ inputs.terraform-state-table }}
+        bucketName: ${{ inputs.terraform-state-bucket }}
 
-    # - name: Store Lockfile
-    #   if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}
-    #   uses: cloudposse/github-action-terraform-plan-storage@v1
-    #   with:
-    #     action: storePlan
-    #     planPath: ${{ inputs.component-path}}/.terraform.lock.hcl
-    #     component: ${{ inputs.component }}
-    #     stack: "${{ inputs.stack }}-lockfile"
-    #     tableName: ${{ inputs.terraform-state-table }}
-    #     bucketName: ${{ inputs.terraform-state-bucket }}
-
+    - name: Store Lockfile
+      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}
+      uses: cloudposse/github-action-terraform-plan-storage@v1
+      with:
+        action: storePlan
+        planPath: ${{ inputs.component-path}}/.terraform.lock.hcl
+        component: ${{ inputs.component }}
+        stack: "${{ inputs.stack }}-lockfile"
+        tableName: ${{ inputs.terraform-state-table }}
+        bucketName: ${{ inputs.terraform-state-bucket }}
 
     # - name: Setup Infracost
     #   if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}

--- a/action.yml
+++ b/action.yml
@@ -14,8 +14,8 @@ inputs:
   component-path:
     description: "The path to the base component. Atmos defines this value as component_path."
     required: true
-  sha:
-    description: "Commit SHA to use when building plan file name. Default: github.sha"
+  plan-id:
+    description: "Suffix that will be used for plan file name to uniquely identify it. Default: github.sha"
     required: true
     default: "${{ github.sha }}"
   terraform-plan-role:
@@ -134,7 +134,7 @@ runs:
       id: atmos-plan
       shell: bash
       run: |
-        PLAN_FILE=$(echo "${{ inputs.stack }}-${{ inputs.component }}-${{ inputs.sha }}.planfile" | sed 's#/#_#g') 
+        PLAN_FILE=$(echo "${{ inputs.stack }}-${{ inputs.component }}-${{ inputs.plan-id }}.planfile" | sed 's#/#_#g') 
         PLAN_FILE_PATH=$(pwd)
 
         TERRAFORM_OUTPUT=$(ATMOS_BASE_PATH=$GITHUB_WORKSPACE atmos terraform plan ${{ inputs.component }} \
@@ -143,8 +143,6 @@ runs:
           -lock=false \
           -input=false \
           -no-color)
-
-        echo "$TERRAFORM_OUTPUT"
 
         if echo "$TERRAFORM_OUTPUT" | grep -q '^No changes. Your infrastructure matches the configuration.'; then
           echo "has_changes=false" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -159,26 +159,26 @@ runs:
         echo "has_changes: ${{ steps.atmos-plan.outputs.has_changes }}"
         echo "has_changes_json: ${{ fromJSON(steps.atmos-plan.outputs.has_changes) }}"
 
-    - name: Configure State AWS Credentials
-      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}
-      uses: aws-actions/configure-aws-credentials@v2.2.0
-      with:
-        aws-region: ${{ inputs.aws-region }}
-        role-to-assume: ${{ inputs.terraform-state-role }}
-        role-session-name: "atmos-terraform-state-gitops"
-        mask-aws-account-id: "no"
+    # - name: Configure State AWS Credentials
+    #   if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}
+    #   uses: aws-actions/configure-aws-credentials@v2.2.0
+    #   with:
+    #     aws-region: ${{ inputs.aws-region }}
+    #     role-to-assume: ${{ inputs.terraform-state-role }}
+    #     role-session-name: "atmos-terraform-state-gitops"
+    #     mask-aws-account-id: "no"
 
-    - name: Store Plan
-      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}
-      uses: cloudposse/github-action-terraform-plan-storage@v1
-      id: store-plan
-      with:
-        action: storePlan
-        planPath: ${{ steps.atmos-plan.outputs.plan_file }}
-        component: ${{ inputs.component }}
-        stack: ${{ inputs.stack }}
-        tableName: ${{ inputs.terraform-state-table }}
-        bucketName: ${{ inputs.terraform-state-bucket }}
+    # - name: Store Plan
+    #   if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}
+    #   uses: cloudposse/github-action-terraform-plan-storage@v1
+    #   id: store-plan
+    #   with:
+    #     action: storePlan
+    #     planPath: ${{ steps.atmos-plan.outputs.plan_file }}
+    #     component: ${{ inputs.component }}
+    #     stack: ${{ inputs.stack }}
+    #     tableName: ${{ inputs.terraform-state-table }}
+    #     bucketName: ${{ inputs.terraform-state-bucket }}
 
     # - name: Store Lockfile
     #   if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}

--- a/action.yml
+++ b/action.yml
@@ -144,13 +144,6 @@ runs:
           --stack ${{ inputs.stack }} \
           -out=$PLAN_FILE_PATH/$PLAN_FILE \
           -input=false -detailed-exitcode
-        
-        PLAN_FILE_JSON="$PLAN_FILE_PATH/$PLAN_FILE.json"
-        terraform show -json "$PLAN_FILE_PATH/$PLAN_FILE" > $PLAN_FILE_JSON
-
-        cat $PLAN_FILE_JSON
-        jq . $PLAN_FILE_JSON
-
         EXIT_CODE=$?
         echo "EXIT_CODE: $EXIT_CODE"
         if [[ "$EXIT_CODE" != "0" ]]; then
@@ -160,6 +153,17 @@ runs:
         fi
         echo "plan_file=$PLAN_FILE" >> $GITHUB_OUTPUT
         echo "plan_file_path=$PLAN_FILE_PATH" >> $GITHUB_OUTPUT
+
+    - name: json
+      shell: bash
+      run: |
+        PLAN_FILE_JSON="${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json"
+
+        cd ${{ inputs.component-path }}
+        terraform show -json "$PLAN_FILE_PATH/$PLAN_FILE" > $PLAN_FILE_JSON
+
+        cat $PLAN_FILE_JSON
+        jq . $PLAN_FILE_JSON
 
     - name: Configure State AWS Credentials
       if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}

--- a/action.yml
+++ b/action.yml
@@ -160,14 +160,6 @@ runs:
         echo "plan_file=$PLAN_FILE" >> $GITHUB_OUTPUT
         echo "plan_file_path=$PLAN_FILE_PATH" >> $GITHUB_OUTPUT
 
-    - name: Has Changes
-      id: has-changes
-      shell: bash
-      run: |
-        echo ${{ steps.atmos-plan.outputs.has_changes }}
-        echo ${{ fromJSON(steps.atmos-plan.outputs.has_changes) }}
-        echo ${{ fromJSON(steps.atmos-plan.outputs.has_changes) == false }}
-
     - name: Configure State AWS Credentials
       if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}
       uses: aws-actions/configure-aws-credentials@v2.2.0
@@ -177,100 +169,100 @@ runs:
         role-session-name: "atmos-terraform-state-gitops"
         mask-aws-account-id: "no"
 
-    # - name: Store Plan
-    #   if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}
-    #   uses: cloudposse/github-action-terraform-plan-storage@v1
-    #   id: store-plan
-    #   with:
-    #     action: storePlan
-    #     planPath: ${{ steps.atmos-plan.outputs.plan_file }}
-    #     component: ${{ inputs.component }}
-    #     stack: ${{ inputs.stack }}
-    #     tableName: ${{ inputs.terraform-state-table }}
-    #     bucketName: ${{ inputs.terraform-state-bucket }}
+    - name: Store Plan
+      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}
+      uses: cloudposse/github-action-terraform-plan-storage@v1
+      id: store-plan
+      with:
+        action: storePlan
+        planPath: ${{ steps.atmos-plan.outputs.plan_file }}
+        component: ${{ inputs.component }}
+        stack: ${{ inputs.stack }}
+        tableName: ${{ inputs.terraform-state-table }}
+        bucketName: ${{ inputs.terraform-state-bucket }}
 
-    # - name: Store Lockfile
-    #   if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}
-    #   uses: cloudposse/github-action-terraform-plan-storage@v1
-    #   with:
-    #     action: storePlan
-    #     planPath: ${{ inputs.component-path}}/.terraform.lock.hcl
-    #     component: ${{ inputs.component }}
-    #     stack: "${{ inputs.stack }}-lockfile"
-    #     tableName: ${{ inputs.terraform-state-table }}
-    #     bucketName: ${{ inputs.terraform-state-bucket }}
+    - name: Store Lockfile
+      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}
+      uses: cloudposse/github-action-terraform-plan-storage@v1
+      with:
+        action: storePlan
+        planPath: ${{ inputs.component-path}}/.terraform.lock.hcl
+        component: ${{ inputs.component }}
+        stack: "${{ inputs.stack }}-lockfile"
+        tableName: ${{ inputs.terraform-state-table }}
+        bucketName: ${{ inputs.terraform-state-bucket }}
 
-    # - name: Setup Infracost
-    #   if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
-    #   uses: infracost/actions/setup@v2
-    #   with:
-    #     api-key: ${{ inputs.infracost-api-key }}
+    - name: Setup Infracost
+      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
+      uses: infracost/actions/setup@v2
+      with:
+        api-key: ${{ inputs.infracost-api-key }}
 
-    # - name: Generate Infracost diff
-    #   if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
-    #   shell: bash
-    #   run: |
-    #     PLAN_FILE="${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}"
-    #     PLAN_FILE_JSON="${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json"
+    - name: Generate Infracost diff
+      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
+      shell: bash
+      run: |
+        PLAN_FILE="${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}"
+        PLAN_FILE_JSON="${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json"
 
-    #     cd ${{ inputs.component-path }}
-    #     terraform show -json $PLAN_FILE > $PLAN_FILE_JSON
+        cd ${{ inputs.component-path }}
+        terraform show -json $PLAN_FILE > $PLAN_FILE_JSON
 
-    #     infracost diff \
-    #       --path=$PLAN_FILE_JSON \
-    #       --format=diff \
-    #       --project-name ${{ inputs.stack }}-${{ inputs.component }} \
-    #       --out-file=/tmp/infracost.txt
-    #     infracost diff \
-    #       --path=$PLAN_FILE_JSON \
-    #       --format=json \
-    #       --project-name ${{ inputs.stack }}-${{ inputs.component }} \
-    #       --out-file=/tmp/infracost.json
+        infracost diff \
+          --path=$PLAN_FILE_JSON \
+          --format=diff \
+          --project-name ${{ inputs.stack }}-${{ inputs.component }} \
+          --out-file=/tmp/infracost.txt
+        infracost diff \
+          --path=$PLAN_FILE_JSON \
+          --format=json \
+          --project-name ${{ inputs.stack }}-${{ inputs.component }} \
+          --out-file=/tmp/infracost.json
 
-    # - if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) && fromJSON(inputs.debug) }}
-    #   shell: bash
-    #   run: |
-    #     cat ${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json
-    #     cat /tmp/infracost.txt
-    #     cat /tmp/infracost.json
+    - if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) && fromJSON(inputs.debug) }}
+      shell: bash
+      run: |
+        cat ${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json
+        cat /tmp/infracost.txt
+        cat /tmp/infracost.json
 
-    # - name: Set infracost variables
-    #   if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
-    #   id: infracost-diff
-    #   shell: bash
-    #   run: |
-    #     if [[ "${{ inputs.enable-infracost }}" == "true" ]]; then
-    #       INFRACOST_DIFF_TOTAL_MONTHLY_COST=$(cat /tmp/infracost.json | jq --raw-output .diffTotalMonthlyCost)
-    #       INFRACOST_DETAILS_DIFF_BREAKDOWN="$(cat /tmp/infracost.txt | base64 --wrap 0)"
-    #     else
-    #       INFRACOST_DIFF_TOTAL_MONTHLY_COST="0"
-    #       INFRACOST_DETAILS_DIFF_BREAKDOWN=""
-    #     fi
+    - name: Set infracost variables
+      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
+      id: infracost-diff
+      shell: bash
+      run: |
+        if [[ "${{ inputs.enable-infracost }}" == "true" ]]; then
+          INFRACOST_DIFF_TOTAL_MONTHLY_COST=$(cat /tmp/infracost.json | jq --raw-output .diffTotalMonthlyCost)
+          INFRACOST_DETAILS_DIFF_BREAKDOWN="$(cat /tmp/infracost.txt | base64 --wrap 0)"
+        else
+          INFRACOST_DIFF_TOTAL_MONTHLY_COST="0"
+          INFRACOST_DETAILS_DIFF_BREAKDOWN=""
+        fi
 
-    #     echo "infracost_details_diff_breakdown=$INFRACOST_DETAILS_DIFF_BREAKDOWN" >> "$GITHUB_OUTPUT"
-    #     echo "infracost_diff_total_monthly_cost=$INFRACOST_DIFF_TOTAL_MONTHLY_COST" >> "$GITHUB_OUTPUT"
+        echo "infracost_details_diff_breakdown=$INFRACOST_DETAILS_DIFF_BREAKDOWN" >> "$GITHUB_OUTPUT"
+        echo "infracost_diff_total_monthly_cost=$INFRACOST_DIFF_TOTAL_MONTHLY_COST" >> "$GITHUB_OUTPUT"
 
-    # - name: Post Plan
-    #   if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
-    #   id: post-plan
-    #   shell: bash
-    #   run: |
-    #     if [[ "${{ inputs.debug }}" == "true" ]]; then
-    #       LOG_LEVEL="DEBUG"
-    #     else
-    #       LOG_LEVEL="INFO"
-    #     fi
-    #     cd ${{ inputs.component-path }}
-    #     tfcmt \
-    #       --config "${{ github.action_path }}/config/atmos_github_summary.yaml" \
-    #       -owner "${{ github.repository_owner }}" \
-    #       -repo "${{ github.event.repository.name }}" \
-    #       -var "target:${{ inputs.stack }}-${{ inputs.component }}" \
-    #       -var "component:${{ inputs.component }}" \
-    #       -var "stack:${{ inputs.stack }}" \
-    #       -var "job:${{ github.job }}" \
-    #       -var "infracost_details_diff_breakdown:${{ steps.infracost-diff.outputs.infracost_details_diff_breakdown }}" \
-    #       -var "infracost_total_monthly_cost:${{ steps.infracost-diff.outputs.infracost_diff_total_monthly_cost }}" \
-    #       --output $GITHUB_STEP_SUMMARY \
-    #       --log-level $LOG_LEVEL \
-    #       plan -- terraform show ${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}
+    - name: Post Plan
+      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
+      id: post-plan
+      shell: bash
+      run: |
+        if [[ "${{ inputs.debug }}" == "true" ]]; then
+          LOG_LEVEL="DEBUG"
+        else
+          LOG_LEVEL="INFO"
+        fi
+        cd ${{ inputs.component-path }}
+        tfcmt \
+          --config "${{ github.action_path }}/config/atmos_github_summary.yaml" \
+          -owner "${{ github.repository_owner }}" \
+          -repo "${{ github.event.repository.name }}" \
+          -var "target:${{ inputs.stack }}-${{ inputs.component }}" \
+          -var "component:${{ inputs.component }}" \
+          -var "stack:${{ inputs.stack }}" \
+          -var "job:${{ github.job }}" \
+          -var "infracost_details_diff_breakdown:${{ steps.infracost-diff.outputs.infracost_details_diff_breakdown }}" \
+          -var "infracost_total_monthly_cost:${{ steps.infracost-diff.outputs.infracost_diff_total_monthly_cost }}" \
+          --output $GITHUB_STEP_SUMMARY \
+          --log-level $LOG_LEVEL \
+          plan -- terraform show ${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}

--- a/action.yml
+++ b/action.yml
@@ -150,10 +150,15 @@ runs:
       id: plan-state
       shell: bash
       run: |
+        ls -l
+        pwd
+
         PLAN_FILE="${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}"
         PLAN_FILE_JSON="${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json"
 
         cd ${{ inputs.component-path }}
+        ls -l
+        pwd
         terraform show -json $PLAN_FILE > $PLAN_FILE_JSON
 
         HAS_CHANGES=$(jq '.resource_changes[] | select(.change.actions[] != "no-op")' "${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json")

--- a/action.yml
+++ b/action.yml
@@ -156,12 +156,15 @@ runs:
         PLAN_FILE="${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}"
         PLAN_FILE_JSON="${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json"
 
-        cd ${{ inputs.component-path }}
-        ls -l
-        pwd
+        echo $PLAN_FILE
+        echo $PLAN_FILE_JSON
+
         terraform show -json $PLAN_FILE > $PLAN_FILE_JSON
 
+        cat $PLAN_FILE_JSON | jq .
+
         HAS_CHANGES=$(jq '.resource_changes[] | select(.change.actions[] != "no-op")' "${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json")
+        echo "HAS_CHANGES=$HAS_CHANGES"
 
         if [[ "$HAS_CHANGES" == "" ]]; then
           echo "HAS_CHANGES=false" >> $GITHUB_ENV

--- a/action.yml
+++ b/action.yml
@@ -243,7 +243,7 @@ runs:
         echo "infracost_diff_total_monthly_cost=$INFRACOST_DIFF_TOTAL_MONTHLY_COST" >> "$GITHUB_OUTPUT"
 
     - name: Post Plan
-      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
+      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}
       id: post-plan
       shell: bash
       run: |

--- a/action.yml
+++ b/action.yml
@@ -144,6 +144,13 @@ runs:
           --stack ${{ inputs.stack }} \
           -out=$PLAN_FILE_PATH/$PLAN_FILE \
           -input=false -detailed-exitcode
+        
+        PLAN_FILE_JSON="${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json"
+        terraform show -json "${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}" > $PLAN_FILE_JSON
+
+        cat $PLAN_FILE_JSON
+        jq . $PLAN_FILE_JSON
+
         EXIT_CODE=$?
         echo "EXIT_CODE: $EXIT_CODE"
         if [[ "$EXIT_CODE" != "0" ]]; then

--- a/action.yml
+++ b/action.yml
@@ -156,14 +156,17 @@ runs:
         cd ${{ inputs.component-path }}
         terraform show -json $PLAN_FILE > $PLAN_FILE_JSON
 
+        cat $PLAN_FILE_JSON
+
+        jq --version
         jq . $PLAN_FILE_JSON
 
-        HAS_CHANGES=$(jq '.resource_changes[] | select(.change.actions[] != "no-op")' $PLAN_FILE_JSON)
-        echo "HAS_CHANGES=$HAS_CHANGES"
+        # HAS_CHANGES=$(jq '.resource_changes[] | select(.change.actions[] != "no-op")' $PLAN_FILE_JSON)
+        # echo "HAS_CHANGES=$HAS_CHANGES"
 
-        if [[ "$HAS_CHANGES" == "" ]]; then
-          echo "HAS_CHANGES=false" >> $GITHUB_ENV
-        fi
+        # if [[ "$HAS_CHANGES" == "" ]]; then
+        #   echo "HAS_CHANGES=false" >> $GITHUB_ENV
+        # fi
 
     - name: Configure State AWS Credentials
       if: env.HAS_CHANGES == 'true'

--- a/action.yml
+++ b/action.yml
@@ -103,7 +103,6 @@ runs:
         else
           echo "actions_enabled=false" >> $GITHUB_OUTPUT
         fi
-        echo "HAS_CHANGES=true" >> $GITHUB_ENV
 
     # setup-tfcmt requires this PATH update when running on self-hosted (amazon linux)
     # https://github.com/shmokmt/actions-setup-tfcmt/blob/main/action.yml#L11C1-L12C1
@@ -145,6 +144,8 @@ runs:
         EXIT_CODE=$?
         if [[ "$EXIT_CODE" != "0" ]]; then
           echo "has_changes='true'" >> $GITHUB_OUTPUT
+        else
+          echo "has_changes='false'" >> $GITHUB_OUTPUT
         fi
         echo "plan_file=$PLAN_FILE" >> $GITHUB_OUTPUT
         echo "plan_file_path=$PLAN_FILE_PATH" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -14,8 +14,8 @@ inputs:
   component-path:
     description: "The path to the base component. Atmos defines this value as component_path."
     required: true
-  sha:
-    description: "Commit SHA that will be used as suffix for plan file"
+  plan-file-suffix:
+    description: "Suffix that is used to build plan file name. Default: '${{ github.sha }}'"
     required: true
     default: ${{ github.sha }}
   terraform-plan-role:
@@ -131,7 +131,7 @@ runs:
       id: atmos-plan
       shell: bash
       run: |
-        PLAN_FILE=$(echo "${{ inputs.stack }}-${{ inputs.component }}-${{inputs.sha}}.planfile" | sed 's#/#_#g') 
+        PLAN_FILE=$(echo "${{ inputs.stack }}-${{ inputs.component }}-${{ inputs.plan-file-suffix }}.planfile" | sed 's#/#_#g') 
         PLAN_FILE_PATH=$(pwd)
         ATMOS_BASE_PATH=$GITHUB_WORKSPACE atmos terraform plan ${{ inputs.component }} \
           --stack ${{ inputs.stack }} \

--- a/action.yml
+++ b/action.yml
@@ -87,7 +87,7 @@ runs:
       with:
         atmos-version: ${{ inputs.atmos-version }}
         token: ${{ inputs.token }}
-        install-wrapper: false
+        install-wrapper: true
 
     - name: Filter Atmos Settings Value
       uses: cloudposse/github-action-atmos-get-setting@v0
@@ -97,7 +97,7 @@ runs:
         stack: ${{ inputs.stack }}
         settings-path: github.actions_enabled
 
-    - name: Check if Action is Enable
+    - name: Check if Action is Enabled
       id: settings
       shell: bash
       run: |

--- a/action.yml
+++ b/action.yml
@@ -161,9 +161,10 @@ runs:
         cd ${{ inputs.component-path }}
         terraform show -json $PLAN_FILE > $PLAN_FILE_JSON
 
-        cat $PLAN_FILE_JSON | jq .
+        ls -l ${{ steps.atmos-plan.outputs.plan_file_path }}/
+        cat $PLAN_FILE_JSON
 
-        HAS_CHANGES=$(jq '.resource_changes[] | select(.change.actions[] != "no-op")' "$PLAN_FILE_JSON")
+        HAS_CHANGES=$(jq '.resource_changes[] | select(.change.actions[] != "no-op")' $PLAN_FILE_JSON)
         echo "HAS_CHANGES=$HAS_CHANGES"
 
         if [[ "$HAS_CHANGES" == "" ]]; then

--- a/action.yml
+++ b/action.yml
@@ -14,10 +14,10 @@ inputs:
   component-path:
     description: "The path to the base component. Atmos defines this value as component_path."
     required: true
-  plan-file:
-    description: "Full name of the plan-file to use. If not set plan-file name will be built by pattern '<stack>-<component>-<github.sha>'. Default: ''"
-    required: false
-    default: ''
+  sha:
+    description: "Commit SHA to use when building plan file name. Default: ${{ github.sha }}"
+    required: true
+    default: ${{ github.sha }}
   terraform-plan-role:
     description: "The AWS role to be used to plan Terraform."
     required: true
@@ -134,12 +134,9 @@ runs:
       id: atmos-plan
       shell: bash
       run: |
-        PLAN_FILE=$(echo "${{ inputs.stack }}-${{ inputs.component }}-${{ github.sha }}.planfile" | sed 's#/#_#g') 
-        if [ "${{ inputs.plan-file }}" != "" ]; then
-          PLAN_FILE="${{ inputs.plan-file }}"
-        fi
-
+        PLAN_FILE=$(echo "${{ inputs.stack }}-${{ inputs.component }}-${{ inputs.sha }}.planfile" | sed 's#/#_#g') 
         PLAN_FILE_PATH=$(pwd)
+
         TERRAFORM_OUTPUT=$(ATMOS_BASE_PATH=$GITHUB_WORKSPACE atmos terraform plan ${{ inputs.component }} \
           --stack ${{ inputs.stack }} \
           -out=$PLAN_FILE_PATH/$PLAN_FILE \

--- a/action.yml
+++ b/action.yml
@@ -198,6 +198,7 @@ runs:
       if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
       shell: bash
       run: |
+        PLAN_FILE="${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}"
         PLAN_FILE_JSON="${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json"
 
         cd ${{ inputs.component-path }}

--- a/action.yml
+++ b/action.yml
@@ -168,7 +168,7 @@ runs:
 
         sleep 3
 
-        jq . $PLAN_FILE_JSON
+        jq -e . $PLAN_FILE_JSON
 
     - name: Configure State AWS Credentials
       if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}

--- a/action.yml
+++ b/action.yml
@@ -148,9 +148,9 @@ runs:
         echo "$TERRAFORM_OUTPUT"
 
         if echo "$TERRAFORM_OUTPUT" | grep -q '^No changes. Your infrastructure matches the configuration.'; then
-          echo "has_changes=true" >> $GITHUB_OUTPUT
-        else
           echo "has_changes=false" >> $GITHUB_OUTPUT
+        else
+          echo "has_changes=true" >> $GITHUB_OUTPUT
         fi
 
         echo "plan_file=$PLAN_FILE" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -60,12 +60,6 @@ inputs:
       GHES, you can pass a personal access token for github.com if you are experiencing rate limiting.
     default: ${{ github.server_url == 'https://github.com' && github.token || '' }}
 outputs:
-  plan-file-path:
-    description: Plan File
-    value: ${{ steps.atmos-plan.outputs.plan_file_path }}
-  plan-file:
-    description: Plan File
-    value: ${{ steps.atmos-plan.outputs.plan_file }}
   has-changes:
     description: Has Changes
     value: ${{ steps.atmos-plan.outputs.has_changes }}

--- a/action.yml
+++ b/action.yml
@@ -150,19 +150,17 @@ runs:
       id: plan-state
       shell: bash
       run: |
-        echo "here0"
-        terraform show -json "${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}" > "${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json"
-        echo "here1"
+        PLAN_FILE="${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}"
+        PLAN_FILE_JSON="${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json"
+
+        cd ${{ inputs.component-path }}
+        terraform show -json $PLAN_FILE > $PLAN_FILE_JSON
+
         HAS_CHANGES=$(jq '.resource_changes[] | select(.change.actions[] != "no-op")' "${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json")
-        echo "here2"
 
         if [[ "$HAS_CHANGES" == "" ]]; then
-          echo "here3"
           echo "HAS_CHANGES=false" >> $GITHUB_ENV
-          echo "here4"
         fi
-
-        echo "here5"
 
     - name: Configure State AWS Credentials
       if: env.HAS_CHANGES == 'true'
@@ -206,7 +204,6 @@ runs:
       if: ${{ env.HAS_CHANGES == 'true' && fromJSON(inputs.enable-infracost) }}
       shell: bash
       run: |
-        PLAN_FILE="${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}"
         PLAN_FILE_JSON="${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json"
 
         cd ${{ inputs.component-path }}

--- a/action.yml
+++ b/action.yml
@@ -186,76 +186,76 @@ runs:
         tableName: ${{ inputs.terraform-state-table }}
         bucketName: ${{ inputs.terraform-state-bucket }}
 
-    - name: Setup Infracost
-      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
-      uses: infracost/actions/setup@v2
-      with:
-        api-key: ${{ inputs.infracost-api-key }}
+    # - name: Setup Infracost
+    #   if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
+    #   uses: infracost/actions/setup@v2
+    #   with:
+    #     api-key: ${{ inputs.infracost-api-key }}
 
-    - name: Generate Infracost diff
-      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
-      shell: bash
-      run: |
-        PLAN_FILE_JSON="${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json"
+    # - name: Generate Infracost diff
+    #   if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
+    #   shell: bash
+    #   run: |
+    #     PLAN_FILE_JSON="${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json"
 
-        cd ${{ inputs.component-path }}
-        terraform show -json $PLAN_FILE > $PLAN_FILE_JSON
+    #     cd ${{ inputs.component-path }}
+    #     terraform show -json $PLAN_FILE > $PLAN_FILE_JSON
 
-        infracost diff \
-          --path=$PLAN_FILE_JSON \
-          --format=diff \
-          --project-name ${{ inputs.stack }}-${{ inputs.component }} \
-          --out-file=/tmp/infracost.txt
-        infracost diff \
-          --path=$PLAN_FILE_JSON \
-          --format=json \
-          --project-name ${{ inputs.stack }}-${{ inputs.component }} \
-          --out-file=/tmp/infracost.json
+    #     infracost diff \
+    #       --path=$PLAN_FILE_JSON \
+    #       --format=diff \
+    #       --project-name ${{ inputs.stack }}-${{ inputs.component }} \
+    #       --out-file=/tmp/infracost.txt
+    #     infracost diff \
+    #       --path=$PLAN_FILE_JSON \
+    #       --format=json \
+    #       --project-name ${{ inputs.stack }}-${{ inputs.component }} \
+    #       --out-file=/tmp/infracost.json
 
-    - if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) && fromJSON(inputs.debug) }}
-      shell: bash
-      run: |
-        cat ${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json
-        cat /tmp/infracost.txt
-        cat /tmp/infracost.json
+    # - if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) && fromJSON(inputs.debug) }}
+    #   shell: bash
+    #   run: |
+    #     cat ${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json
+    #     cat /tmp/infracost.txt
+    #     cat /tmp/infracost.json
 
-    - name: Set infracost variables
-      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
-      id: infracost-diff
-      shell: bash
-      run: |
-        if [[ "${{ inputs.enable-infracost }}" == "true" ]]; then
-          INFRACOST_DIFF_TOTAL_MONTHLY_COST=$(cat /tmp/infracost.json | jq --raw-output .diffTotalMonthlyCost)
-          INFRACOST_DETAILS_DIFF_BREAKDOWN="$(cat /tmp/infracost.txt | base64 --wrap 0)"
-        else
-          INFRACOST_DIFF_TOTAL_MONTHLY_COST="0"
-          INFRACOST_DETAILS_DIFF_BREAKDOWN=""
-        fi
+    # - name: Set infracost variables
+    #   if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
+    #   id: infracost-diff
+    #   shell: bash
+    #   run: |
+    #     if [[ "${{ inputs.enable-infracost }}" == "true" ]]; then
+    #       INFRACOST_DIFF_TOTAL_MONTHLY_COST=$(cat /tmp/infracost.json | jq --raw-output .diffTotalMonthlyCost)
+    #       INFRACOST_DETAILS_DIFF_BREAKDOWN="$(cat /tmp/infracost.txt | base64 --wrap 0)"
+    #     else
+    #       INFRACOST_DIFF_TOTAL_MONTHLY_COST="0"
+    #       INFRACOST_DETAILS_DIFF_BREAKDOWN=""
+    #     fi
 
-        echo "infracost_details_diff_breakdown=$INFRACOST_DETAILS_DIFF_BREAKDOWN" >> "$GITHUB_OUTPUT"
-        echo "infracost_diff_total_monthly_cost=$INFRACOST_DIFF_TOTAL_MONTHLY_COST" >> "$GITHUB_OUTPUT"
+    #     echo "infracost_details_diff_breakdown=$INFRACOST_DETAILS_DIFF_BREAKDOWN" >> "$GITHUB_OUTPUT"
+    #     echo "infracost_diff_total_monthly_cost=$INFRACOST_DIFF_TOTAL_MONTHLY_COST" >> "$GITHUB_OUTPUT"
 
-    - name: Post Plan
-      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
-      id: post-plan
-      shell: bash
-      run: |
-        if [[ "${{ inputs.debug }}" == "true" ]]; then
-          LOG_LEVEL="DEBUG"
-        else
-          LOG_LEVEL="INFO"
-        fi
-        cd ${{ inputs.component-path }}
-        tfcmt \
-          --config "${{ github.action_path }}/config/atmos_github_summary.yaml" \
-          -owner "${{ github.repository_owner }}" \
-          -repo "${{ github.event.repository.name }}" \
-          -var "target:${{ inputs.stack }}-${{ inputs.component }}" \
-          -var "component:${{ inputs.component }}" \
-          -var "stack:${{ inputs.stack }}" \
-          -var "job:${{ github.job }}" \
-          -var "infracost_details_diff_breakdown:${{ steps.infracost-diff.outputs.infracost_details_diff_breakdown }}" \
-          -var "infracost_total_monthly_cost:${{ steps.infracost-diff.outputs.infracost_diff_total_monthly_cost }}" \
-          --output $GITHUB_STEP_SUMMARY \
-          --log-level $LOG_LEVEL \
-          plan -- terraform show ${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}
+    # - name: Post Plan
+    #   if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
+    #   id: post-plan
+    #   shell: bash
+    #   run: |
+    #     if [[ "${{ inputs.debug }}" == "true" ]]; then
+    #       LOG_LEVEL="DEBUG"
+    #     else
+    #       LOG_LEVEL="INFO"
+    #     fi
+    #     cd ${{ inputs.component-path }}
+    #     tfcmt \
+    #       --config "${{ github.action_path }}/config/atmos_github_summary.yaml" \
+    #       -owner "${{ github.repository_owner }}" \
+    #       -repo "${{ github.event.repository.name }}" \
+    #       -var "target:${{ inputs.stack }}-${{ inputs.component }}" \
+    #       -var "component:${{ inputs.component }}" \
+    #       -var "stack:${{ inputs.stack }}" \
+    #       -var "job:${{ github.job }}" \
+    #       -var "infracost_details_diff_breakdown:${{ steps.infracost-diff.outputs.infracost_details_diff_breakdown }}" \
+    #       -var "infracost_total_monthly_cost:${{ steps.infracost-diff.outputs.infracost_diff_total_monthly_cost }}" \
+    #       --output $GITHUB_STEP_SUMMARY \
+    #       --log-level $LOG_LEVEL \
+    #       plan -- terraform show ${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}

--- a/action.yml
+++ b/action.yml
@@ -150,6 +150,7 @@ runs:
       id: plan-state
       shell: bash
       run: |
+        echo "here0"
         terraform show -json "${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}" > "${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json"
         echo "here1"
         HAS_CHANGES=$(jq '.resource_changes[] | select(.change.actions[] != "no-op")' "${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json")

--- a/action.yml
+++ b/action.yml
@@ -142,6 +142,7 @@ runs:
           -out=$PLAN_FILE_PATH/$PLAN_FILE \
           -input=false -detailed-exitcode
         EXIT_CODE=$?
+        echo "EXIT_CODE: $EXIT_CODE"
         if [[ "$EXIT_CODE" != "0" ]]; then
           echo "has_changes='true'" >> $GITHUB_OUTPUT
         else

--- a/action.yml
+++ b/action.yml
@@ -151,12 +151,11 @@ runs:
 
         if echo "$TERRAFORM_OUTPUT" | grep -q '^No changes. Your infrastructure matches the configuration.'; then
           echo "has_changes=false" >> $GITHUB_OUTPUT
+          echo "No changes"
         else
           echo "has_changes=true" >> $GITHUB_OUTPUT
+          echo "Found changes"
         fi
-
-        echo "all outputs: "
-        echo $GITHUB_OUTPUT
 
         echo "plan_file=$PLAN_FILE" >> $GITHUB_OUTPUT
         echo "plan_file_path=$PLAN_FILE_PATH" >> $GITHUB_OUTPUT
@@ -178,100 +177,100 @@ runs:
         role-session-name: "atmos-terraform-state-gitops"
         mask-aws-account-id: "no"
 
-    - name: Store Plan
-      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}
-      uses: cloudposse/github-action-terraform-plan-storage@v1
-      id: store-plan
-      with:
-        action: storePlan
-        planPath: ${{ steps.atmos-plan.outputs.plan_file }}
-        component: ${{ inputs.component }}
-        stack: ${{ inputs.stack }}
-        tableName: ${{ inputs.terraform-state-table }}
-        bucketName: ${{ inputs.terraform-state-bucket }}
+    # - name: Store Plan
+    #   if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}
+    #   uses: cloudposse/github-action-terraform-plan-storage@v1
+    #   id: store-plan
+    #   with:
+    #     action: storePlan
+    #     planPath: ${{ steps.atmos-plan.outputs.plan_file }}
+    #     component: ${{ inputs.component }}
+    #     stack: ${{ inputs.stack }}
+    #     tableName: ${{ inputs.terraform-state-table }}
+    #     bucketName: ${{ inputs.terraform-state-bucket }}
 
-    - name: Store Lockfile
-      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}
-      uses: cloudposse/github-action-terraform-plan-storage@v1
-      with:
-        action: storePlan
-        planPath: ${{ inputs.component-path}}/.terraform.lock.hcl
-        component: ${{ inputs.component }}
-        stack: "${{ inputs.stack }}-lockfile"
-        tableName: ${{ inputs.terraform-state-table }}
-        bucketName: ${{ inputs.terraform-state-bucket }}
+    # - name: Store Lockfile
+    #   if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}
+    #   uses: cloudposse/github-action-terraform-plan-storage@v1
+    #   with:
+    #     action: storePlan
+    #     planPath: ${{ inputs.component-path}}/.terraform.lock.hcl
+    #     component: ${{ inputs.component }}
+    #     stack: "${{ inputs.stack }}-lockfile"
+    #     tableName: ${{ inputs.terraform-state-table }}
+    #     bucketName: ${{ inputs.terraform-state-bucket }}
 
-    - name: Setup Infracost
-      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
-      uses: infracost/actions/setup@v2
-      with:
-        api-key: ${{ inputs.infracost-api-key }}
+    # - name: Setup Infracost
+    #   if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
+    #   uses: infracost/actions/setup@v2
+    #   with:
+    #     api-key: ${{ inputs.infracost-api-key }}
 
-    - name: Generate Infracost diff
-      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
-      shell: bash
-      run: |
-        PLAN_FILE="${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}"
-        PLAN_FILE_JSON="${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json"
+    # - name: Generate Infracost diff
+    #   if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
+    #   shell: bash
+    #   run: |
+    #     PLAN_FILE="${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}"
+    #     PLAN_FILE_JSON="${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json"
 
-        cd ${{ inputs.component-path }}
-        terraform show -json $PLAN_FILE > $PLAN_FILE_JSON
+    #     cd ${{ inputs.component-path }}
+    #     terraform show -json $PLAN_FILE > $PLAN_FILE_JSON
 
-        infracost diff \
-          --path=$PLAN_FILE_JSON \
-          --format=diff \
-          --project-name ${{ inputs.stack }}-${{ inputs.component }} \
-          --out-file=/tmp/infracost.txt
-        infracost diff \
-          --path=$PLAN_FILE_JSON \
-          --format=json \
-          --project-name ${{ inputs.stack }}-${{ inputs.component }} \
-          --out-file=/tmp/infracost.json
+    #     infracost diff \
+    #       --path=$PLAN_FILE_JSON \
+    #       --format=diff \
+    #       --project-name ${{ inputs.stack }}-${{ inputs.component }} \
+    #       --out-file=/tmp/infracost.txt
+    #     infracost diff \
+    #       --path=$PLAN_FILE_JSON \
+    #       --format=json \
+    #       --project-name ${{ inputs.stack }}-${{ inputs.component }} \
+    #       --out-file=/tmp/infracost.json
 
-    - if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) && fromJSON(inputs.debug) }}
-      shell: bash
-      run: |
-        cat ${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json
-        cat /tmp/infracost.txt
-        cat /tmp/infracost.json
+    # - if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) && fromJSON(inputs.debug) }}
+    #   shell: bash
+    #   run: |
+    #     cat ${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json
+    #     cat /tmp/infracost.txt
+    #     cat /tmp/infracost.json
 
-    - name: Set infracost variables
-      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
-      id: infracost-diff
-      shell: bash
-      run: |
-        if [[ "${{ inputs.enable-infracost }}" == "true" ]]; then
-          INFRACOST_DIFF_TOTAL_MONTHLY_COST=$(cat /tmp/infracost.json | jq --raw-output .diffTotalMonthlyCost)
-          INFRACOST_DETAILS_DIFF_BREAKDOWN="$(cat /tmp/infracost.txt | base64 --wrap 0)"
-        else
-          INFRACOST_DIFF_TOTAL_MONTHLY_COST="0"
-          INFRACOST_DETAILS_DIFF_BREAKDOWN=""
-        fi
+    # - name: Set infracost variables
+    #   if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
+    #   id: infracost-diff
+    #   shell: bash
+    #   run: |
+    #     if [[ "${{ inputs.enable-infracost }}" == "true" ]]; then
+    #       INFRACOST_DIFF_TOTAL_MONTHLY_COST=$(cat /tmp/infracost.json | jq --raw-output .diffTotalMonthlyCost)
+    #       INFRACOST_DETAILS_DIFF_BREAKDOWN="$(cat /tmp/infracost.txt | base64 --wrap 0)"
+    #     else
+    #       INFRACOST_DIFF_TOTAL_MONTHLY_COST="0"
+    #       INFRACOST_DETAILS_DIFF_BREAKDOWN=""
+    #     fi
 
-        echo "infracost_details_diff_breakdown=$INFRACOST_DETAILS_DIFF_BREAKDOWN" >> "$GITHUB_OUTPUT"
-        echo "infracost_diff_total_monthly_cost=$INFRACOST_DIFF_TOTAL_MONTHLY_COST" >> "$GITHUB_OUTPUT"
+    #     echo "infracost_details_diff_breakdown=$INFRACOST_DETAILS_DIFF_BREAKDOWN" >> "$GITHUB_OUTPUT"
+    #     echo "infracost_diff_total_monthly_cost=$INFRACOST_DIFF_TOTAL_MONTHLY_COST" >> "$GITHUB_OUTPUT"
 
-    - name: Post Plan
-      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
-      id: post-plan
-      shell: bash
-      run: |
-        if [[ "${{ inputs.debug }}" == "true" ]]; then
-          LOG_LEVEL="DEBUG"
-        else
-          LOG_LEVEL="INFO"
-        fi
-        cd ${{ inputs.component-path }}
-        tfcmt \
-          --config "${{ github.action_path }}/config/atmos_github_summary.yaml" \
-          -owner "${{ github.repository_owner }}" \
-          -repo "${{ github.event.repository.name }}" \
-          -var "target:${{ inputs.stack }}-${{ inputs.component }}" \
-          -var "component:${{ inputs.component }}" \
-          -var "stack:${{ inputs.stack }}" \
-          -var "job:${{ github.job }}" \
-          -var "infracost_details_diff_breakdown:${{ steps.infracost-diff.outputs.infracost_details_diff_breakdown }}" \
-          -var "infracost_total_monthly_cost:${{ steps.infracost-diff.outputs.infracost_diff_total_monthly_cost }}" \
-          --output $GITHUB_STEP_SUMMARY \
-          --log-level $LOG_LEVEL \
-          plan -- terraform show ${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}
+    # - name: Post Plan
+    #   if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
+    #   id: post-plan
+    #   shell: bash
+    #   run: |
+    #     if [[ "${{ inputs.debug }}" == "true" ]]; then
+    #       LOG_LEVEL="DEBUG"
+    #     else
+    #       LOG_LEVEL="INFO"
+    #     fi
+    #     cd ${{ inputs.component-path }}
+    #     tfcmt \
+    #       --config "${{ github.action_path }}/config/atmos_github_summary.yaml" \
+    #       -owner "${{ github.repository_owner }}" \
+    #       -repo "${{ github.event.repository.name }}" \
+    #       -var "target:${{ inputs.stack }}-${{ inputs.component }}" \
+    #       -var "component:${{ inputs.component }}" \
+    #       -var "stack:${{ inputs.stack }}" \
+    #       -var "job:${{ github.job }}" \
+    #       -var "infracost_details_diff_breakdown:${{ steps.infracost-diff.outputs.infracost_details_diff_breakdown }}" \
+    #       -var "infracost_total_monthly_cost:${{ steps.infracost-diff.outputs.infracost_diff_total_monthly_cost }}" \
+    #       --output $GITHUB_STEP_SUMMARY \
+    #       --log-level $LOG_LEVEL \
+    #       plan -- terraform show ${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,10 @@ inputs:
   component-path:
     description: "The path to the base component. Atmos defines this value as component_path."
     required: true
+  sha:
+    description: "Commit SHA that will be used as suffix for plan file"
+    required: true
+    default: ${{ github.sha }}
   terraform-plan-role:
     description: "The AWS role to be used to plan Terraform."
     required: true
@@ -127,7 +131,7 @@ runs:
       id: atmos-plan
       shell: bash
       run: |
-        PLAN_FILE=$(echo "${{ inputs.stack }}-${{ inputs.component }}-${{github.sha}}.planfile" | sed 's#/#_#g') 
+        PLAN_FILE=$(echo "${{ inputs.stack }}-${{ inputs.component }}-${{input.sha}}.planfile" | sed 's#/#_#g') 
         PLAN_FILE_PATH=$(pwd)
         ATMOS_BASE_PATH=$GITHUB_WORKSPACE atmos terraform plan ${{ inputs.component }} \
           --stack ${{ inputs.stack }} \

--- a/action.yml
+++ b/action.yml
@@ -158,7 +158,7 @@ runs:
         fi
 
     - name: Configure State AWS Credentials
-      if: ${{ fromJSON(env.HAS_CHANGES) }}
+      if: env.HAS_CHANGES == 'true'
       uses: aws-actions/configure-aws-credentials@v2.2.0
       with:
         aws-region: ${{ inputs.aws-region }}
@@ -167,7 +167,7 @@ runs:
         mask-aws-account-id: "no"
 
     - name: Store Plan
-      if: ${{ fromJSON(env.HAS_CHANGES) }}
+      if: env.HAS_CHANGES == 'true'
       uses: cloudposse/github-action-terraform-plan-storage@v1
       id: store-plan
       with:
@@ -179,7 +179,7 @@ runs:
         bucketName: ${{ inputs.terraform-state-bucket }}
 
     - name: Store Lockfile
-      if: ${{ fromJSON(env.HAS_CHANGES) }}
+      if: env.HAS_CHANGES == 'true'
       uses: cloudposse/github-action-terraform-plan-storage@v1
       with:
         action: storePlan
@@ -190,13 +190,13 @@ runs:
         bucketName: ${{ inputs.terraform-state-bucket }}
 
     - name: Setup Infracost
-      if: ${{ fromJSON(env.HAS_CHANGES) && fromJSON(inputs.enable-infracost) }}
+      if: ${{ env.HAS_CHANGES == 'true' && fromJSON(inputs.enable-infracost) }}
       uses: infracost/actions/setup@v2
       with:
         api-key: ${{ inputs.infracost-api-key }}
 
     - name: Generate Infracost diff
-      if: ${{ fromJSON(env.HAS_CHANGES) && fromJSON(inputs.enable-infracost) }}
+      if: ${{ env.HAS_CHANGES == 'true' && fromJSON(inputs.enable-infracost) }}
       shell: bash
       run: |
         PLAN_FILE="${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}"
@@ -216,7 +216,7 @@ runs:
           --project-name ${{ inputs.stack }}-${{ inputs.component }} \
           --out-file=/tmp/infracost.json
 
-    - if: ${{ fromJSON(env.HAS_CHANGES) && fromJSON(inputs.enable-infracost) && fromJSON(inputs.debug) }}
+    - if: ${{ env.HAS_CHANGES == 'true' && fromJSON(inputs.enable-infracost) && fromJSON(inputs.debug) }}
       shell: bash
       run: |
         cat ${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json
@@ -224,7 +224,7 @@ runs:
         cat /tmp/infracost.json
 
     - name: Set infracost variables
-      if: ${{ fromJSON(env.HAS_CHANGES) }}
+      if: env.HAS_CHANGES == 'true'
       id: infracost-diff
       shell: bash
       run: |
@@ -240,7 +240,7 @@ runs:
         echo "infracost_diff_total_monthly_cost=$INFRACOST_DIFF_TOTAL_MONTHLY_COST" >> "$GITHUB_OUTPUT"
 
     - name: Post Plan
-      if: ${{ fromJSON(env.HAS_CHANGES) }}
+      if: env.HAS_CHANGES == 'true'
       id: post-plan
       shell: bash
       run: |

--- a/action.yml
+++ b/action.yml
@@ -166,24 +166,26 @@ runs:
 
     - name: Store Plan
       if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}
-      uses: cloudposse/github-action-terraform-plan-storage@v1
+      uses: cloudposse/github-action-terraform-plan-storage@added-commitsha-overwrite-input
       id: store-plan
       with:
         action: storePlan
         planPath: ${{ steps.atmos-plan.outputs.plan_file }}
         component: ${{ inputs.component }}
         stack: ${{ inputs.stack }}
+        commitSHA: ${{ inputs.plan-id }}
         tableName: ${{ inputs.terraform-state-table }}
         bucketName: ${{ inputs.terraform-state-bucket }}
 
     - name: Store Lockfile
       if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}
-      uses: cloudposse/github-action-terraform-plan-storage@v1
+      uses: cloudposse/github-action-terraform-plan-storage@added-commitsha-overwrite-input
       with:
         action: storePlan
         planPath: ${{ inputs.component-path}}/.terraform.lock.hcl
         component: ${{ inputs.component }}
         stack: "${{ inputs.stack }}-lockfile"
+        commitSHA: ${{ inputs.plan-id }}
         tableName: ${{ inputs.terraform-state-table }}
         bucketName: ${{ inputs.terraform-state-bucket }}
 

--- a/action.yml
+++ b/action.yml
@@ -131,7 +131,7 @@ runs:
       id: atmos-plan
       shell: bash
       run: |
-        PLAN_FILE=$(echo "${{ inputs.stack }}-${{ inputs.component }}-${{input.sha}}.planfile" | sed 's#/#_#g') 
+        PLAN_FILE=$(echo "${{ inputs.stack }}-${{ inputs.component }}-${{inputs.sha}}.planfile" | sed 's#/#_#g') 
         PLAN_FILE_PATH=$(pwd)
         ATMOS_BASE_PATH=$GITHUB_WORKSPACE atmos terraform plan ${{ inputs.component }} \
           --stack ${{ inputs.stack }} \

--- a/action.yml
+++ b/action.yml
@@ -156,9 +156,6 @@ runs:
         cd ${{ inputs.component-path }}
         terraform show -json $PLAN_FILE > $PLAN_FILE_JSON
 
-        ls -l ${{ steps.atmos-plan.outputs.plan_file_path }}/
-        cat $PLAN_FILE_JSON
-
         jq . $PLAN_FILE_JSON
 
         HAS_CHANGES=$(jq '.resource_changes[] | select(.change.actions[] != "no-op")' $PLAN_FILE_JSON)

--- a/action.yml
+++ b/action.yml
@@ -143,7 +143,9 @@ runs:
         TERRAFORM_OUTPUT=$(ATMOS_BASE_PATH=$GITHUB_WORKSPACE atmos terraform plan ${{ inputs.component }} \
           --stack ${{ inputs.stack }} \
           -out=$PLAN_FILE_PATH/$PLAN_FILE \
-          -input=false -no-color)
+          -lock=false \
+          -input=false \
+          -no-color)
 
         echo "$TERRAFORM_OUTPUT"
 

--- a/action.yml
+++ b/action.yml
@@ -150,19 +150,16 @@ runs:
       id: plan-state
       shell: bash
       run: |
-        set -ex
-
         PLAN_FILE="${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}"
         PLAN_FILE_JSON="${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json"
-
-        echo $PLAN_FILE
-        echo $PLAN_FILE_JSON
 
         cd ${{ inputs.component-path }}
         terraform show -json $PLAN_FILE > $PLAN_FILE_JSON
 
         ls -l ${{ steps.atmos-plan.outputs.plan_file_path }}/
         cat $PLAN_FILE_JSON
+
+        jq . $PLAN_FILE_JSON
 
         HAS_CHANGES=$(jq '.resource_changes[] | select(.change.actions[] != "no-op")' $PLAN_FILE_JSON)
         echo "HAS_CHANGES=$HAS_CHANGES"

--- a/action.yml
+++ b/action.yml
@@ -158,6 +158,13 @@ runs:
         echo "plan_file=$PLAN_FILE" >> $GITHUB_OUTPUT
         echo "plan_file_path=$PLAN_FILE_PATH" >> $GITHUB_OUTPUT
 
+    - name: Has Changes
+      id: has-changes
+      shell: bash
+      run: |
+        echo ${{ steps.atmos-plan.outputs.has_changes }}
+        echo ${{ fromJSON(steps.atmos-plan.outputs.has_changes) }}
+
     - name: Configure State AWS Credentials
       if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}
       uses: aws-actions/configure-aws-credentials@v2.2.0

--- a/action.yml
+++ b/action.yml
@@ -15,9 +15,9 @@ inputs:
     description: "The path to the base component. Atmos defines this value as component_path."
     required: true
   sha:
-    description: "Commit SHA to use when building plan file name. Default: ${{ github.sha }}"
+    description: "Commit SHA to use when building plan file name. Default: github.sha"
     required: true
-    default: ${{ github.sha }}
+    default: "${{ github.sha }}"
   terraform-plan-role:
     description: "The AWS role to be used to plan Terraform."
     required: true

--- a/action.yml
+++ b/action.yml
@@ -154,108 +154,108 @@ runs:
         echo "plan_file=$PLAN_FILE" >> $GITHUB_OUTPUT
         echo "plan_file_path=$PLAN_FILE_PATH" >> $GITHUB_OUTPUT
 
-    # - name: Configure State AWS Credentials
-    #   if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}
-    #   uses: aws-actions/configure-aws-credentials@v2.2.0
-    #   with:
-    #     aws-region: ${{ inputs.aws-region }}
-    #     role-to-assume: ${{ inputs.terraform-state-role }}
-    #     role-session-name: "atmos-terraform-state-gitops"
-    #     mask-aws-account-id: "no"
+    - name: Configure State AWS Credentials
+      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}
+      uses: aws-actions/configure-aws-credentials@v2.2.0
+      with:
+        aws-region: ${{ inputs.aws-region }}
+        role-to-assume: ${{ inputs.terraform-state-role }}
+        role-session-name: "atmos-terraform-state-gitops"
+        mask-aws-account-id: "no"
 
-    # - name: Store Plan
-    #   if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}
-    #   uses: cloudposse/github-action-terraform-plan-storage@v1
-    #   id: store-plan
-    #   with:
-    #     action: storePlan
-    #     planPath: ${{ steps.atmos-plan.outputs.plan_file }}
-    #     component: ${{ inputs.component }}
-    #     stack: ${{ inputs.stack }}
-    #     tableName: ${{ inputs.terraform-state-table }}
-    #     bucketName: ${{ inputs.terraform-state-bucket }}
+    - name: Store Plan
+      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}
+      uses: cloudposse/github-action-terraform-plan-storage@v1
+      id: store-plan
+      with:
+        action: storePlan
+        planPath: ${{ steps.atmos-plan.outputs.plan_file }}
+        component: ${{ inputs.component }}
+        stack: ${{ inputs.stack }}
+        tableName: ${{ inputs.terraform-state-table }}
+        bucketName: ${{ inputs.terraform-state-bucket }}
 
-    # - name: Store Lockfile
-    #   if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}
-    #   uses: cloudposse/github-action-terraform-plan-storage@v1
-    #   with:
-    #     action: storePlan
-    #     planPath: ${{ inputs.component-path}}/.terraform.lock.hcl
-    #     component: ${{ inputs.component }}
-    #     stack: "${{ inputs.stack }}-lockfile"
-    #     tableName: ${{ inputs.terraform-state-table }}
-    #     bucketName: ${{ inputs.terraform-state-bucket }}
+    - name: Store Lockfile
+      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}
+      uses: cloudposse/github-action-terraform-plan-storage@v1
+      with:
+        action: storePlan
+        planPath: ${{ inputs.component-path}}/.terraform.lock.hcl
+        component: ${{ inputs.component }}
+        stack: "${{ inputs.stack }}-lockfile"
+        tableName: ${{ inputs.terraform-state-table }}
+        bucketName: ${{ inputs.terraform-state-bucket }}
 
-    # - name: Setup Infracost
-    #   if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
-    #   uses: infracost/actions/setup@v2
-    #   with:
-    #     api-key: ${{ inputs.infracost-api-key }}
+    - name: Setup Infracost
+      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
+      uses: infracost/actions/setup@v2
+      with:
+        api-key: ${{ inputs.infracost-api-key }}
 
-    # - name: Generate Infracost diff
-    #   if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
-    #   shell: bash
-    #   run: |
-    #     PLAN_FILE_JSON="${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json"
+    - name: Generate Infracost diff
+      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
+      shell: bash
+      run: |
+        PLAN_FILE_JSON="${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json"
 
-    #     cd ${{ inputs.component-path }}
-    #     terraform show -json $PLAN_FILE > $PLAN_FILE_JSON
+        cd ${{ inputs.component-path }}
+        terraform show -json $PLAN_FILE > $PLAN_FILE_JSON
 
-    #     infracost diff \
-    #       --path=$PLAN_FILE_JSON \
-    #       --format=diff \
-    #       --project-name ${{ inputs.stack }}-${{ inputs.component }} \
-    #       --out-file=/tmp/infracost.txt
-    #     infracost diff \
-    #       --path=$PLAN_FILE_JSON \
-    #       --format=json \
-    #       --project-name ${{ inputs.stack }}-${{ inputs.component }} \
-    #       --out-file=/tmp/infracost.json
+        infracost diff \
+          --path=$PLAN_FILE_JSON \
+          --format=diff \
+          --project-name ${{ inputs.stack }}-${{ inputs.component }} \
+          --out-file=/tmp/infracost.txt
+        infracost diff \
+          --path=$PLAN_FILE_JSON \
+          --format=json \
+          --project-name ${{ inputs.stack }}-${{ inputs.component }} \
+          --out-file=/tmp/infracost.json
 
-    # - if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) && fromJSON(inputs.debug) }}
-    #   shell: bash
-    #   run: |
-    #     cat ${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json
-    #     cat /tmp/infracost.txt
-    #     cat /tmp/infracost.json
+    - if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) && fromJSON(inputs.debug) }}
+      shell: bash
+      run: |
+        cat ${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json
+        cat /tmp/infracost.txt
+        cat /tmp/infracost.json
 
-    # - name: Set infracost variables
-    #   if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
-    #   id: infracost-diff
-    #   shell: bash
-    #   run: |
-    #     if [[ "${{ inputs.enable-infracost }}" == "true" ]]; then
-    #       INFRACOST_DIFF_TOTAL_MONTHLY_COST=$(cat /tmp/infracost.json | jq --raw-output .diffTotalMonthlyCost)
-    #       INFRACOST_DETAILS_DIFF_BREAKDOWN="$(cat /tmp/infracost.txt | base64 --wrap 0)"
-    #     else
-    #       INFRACOST_DIFF_TOTAL_MONTHLY_COST="0"
-    #       INFRACOST_DETAILS_DIFF_BREAKDOWN=""
-    #     fi
+    - name: Set infracost variables
+      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
+      id: infracost-diff
+      shell: bash
+      run: |
+        if [[ "${{ inputs.enable-infracost }}" == "true" ]]; then
+          INFRACOST_DIFF_TOTAL_MONTHLY_COST=$(cat /tmp/infracost.json | jq --raw-output .diffTotalMonthlyCost)
+          INFRACOST_DETAILS_DIFF_BREAKDOWN="$(cat /tmp/infracost.txt | base64 --wrap 0)"
+        else
+          INFRACOST_DIFF_TOTAL_MONTHLY_COST="0"
+          INFRACOST_DETAILS_DIFF_BREAKDOWN=""
+        fi
 
-    #     echo "infracost_details_diff_breakdown=$INFRACOST_DETAILS_DIFF_BREAKDOWN" >> "$GITHUB_OUTPUT"
-    #     echo "infracost_diff_total_monthly_cost=$INFRACOST_DIFF_TOTAL_MONTHLY_COST" >> "$GITHUB_OUTPUT"
+        echo "infracost_details_diff_breakdown=$INFRACOST_DETAILS_DIFF_BREAKDOWN" >> "$GITHUB_OUTPUT"
+        echo "infracost_diff_total_monthly_cost=$INFRACOST_DIFF_TOTAL_MONTHLY_COST" >> "$GITHUB_OUTPUT"
 
-    # - name: Post Plan
-    #   if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
-    #   id: post-plan
-    #   shell: bash
-    #   run: |
-    #     if [[ "${{ inputs.debug }}" == "true" ]]; then
-    #       LOG_LEVEL="DEBUG"
-    #     else
-    #       LOG_LEVEL="INFO"
-    #     fi
-    #     cd ${{ inputs.component-path }}
-    #     tfcmt \
-    #       --config "${{ github.action_path }}/config/atmos_github_summary.yaml" \
-    #       -owner "${{ github.repository_owner }}" \
-    #       -repo "${{ github.event.repository.name }}" \
-    #       -var "target:${{ inputs.stack }}-${{ inputs.component }}" \
-    #       -var "component:${{ inputs.component }}" \
-    #       -var "stack:${{ inputs.stack }}" \
-    #       -var "job:${{ github.job }}" \
-    #       -var "infracost_details_diff_breakdown:${{ steps.infracost-diff.outputs.infracost_details_diff_breakdown }}" \
-    #       -var "infracost_total_monthly_cost:${{ steps.infracost-diff.outputs.infracost_diff_total_monthly_cost }}" \
-    #       --output $GITHUB_STEP_SUMMARY \
-    #       --log-level $LOG_LEVEL \
-    #       plan -- terraform show ${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}
+    - name: Post Plan
+      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
+      id: post-plan
+      shell: bash
+      run: |
+        if [[ "${{ inputs.debug }}" == "true" ]]; then
+          LOG_LEVEL="DEBUG"
+        else
+          LOG_LEVEL="INFO"
+        fi
+        cd ${{ inputs.component-path }}
+        tfcmt \
+          --config "${{ github.action_path }}/config/atmos_github_summary.yaml" \
+          -owner "${{ github.repository_owner }}" \
+          -repo "${{ github.event.repository.name }}" \
+          -var "target:${{ inputs.stack }}-${{ inputs.component }}" \
+          -var "component:${{ inputs.component }}" \
+          -var "stack:${{ inputs.stack }}" \
+          -var "job:${{ github.job }}" \
+          -var "infracost_details_diff_breakdown:${{ steps.infracost-diff.outputs.infracost_details_diff_breakdown }}" \
+          -var "infracost_total_monthly_cost:${{ steps.infracost-diff.outputs.infracost_diff_total_monthly_cost }}" \
+          --output $GITHUB_STEP_SUMMARY \
+          --log-level $LOG_LEVEL \
+          plan -- terraform show ${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}

--- a/action.yml
+++ b/action.yml
@@ -140,35 +140,21 @@ runs:
         fi
 
         PLAN_FILE_PATH=$(pwd)
-        ATMOS_BASE_PATH=$GITHUB_WORKSPACE atmos terraform plan ${{ inputs.component }} \
+        TERRAFORM_OUTPUT=$(ATMOS_BASE_PATH=$GITHUB_WORKSPACE atmos terraform plan ${{ inputs.component }} \
           --stack ${{ inputs.stack }} \
           -out=$PLAN_FILE_PATH/$PLAN_FILE \
-          -input=false -detailed-exitcode
-        EXIT_CODE=$?
-        echo "EXIT_CODE: $EXIT_CODE"
-        if [[ "$EXIT_CODE" != "0" ]]; then
+          -input=false -no-color)
+
+        echo "$TERRAFORM_OUTPUT"
+
+        if echo "$TERRAFORM_OUTPUT" | grep -q '^No changes. Your infrastructure matches the configuration.'; then
           echo "has_changes=true" >> $GITHUB_OUTPUT
         else
           echo "has_changes=false" >> $GITHUB_OUTPUT
         fi
+
         echo "plan_file=$PLAN_FILE" >> $GITHUB_OUTPUT
         echo "plan_file_path=$PLAN_FILE_PATH" >> $GITHUB_OUTPUT
-
-    - name: json
-      shell: bash
-      run: |
-        PLAN_FILE_JSON="${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json"
-
-        cd ${{ inputs.component-path }}
-        terraform show -json "${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}" > $PLAN_FILE_JSON
-
-        sleep 3
-
-        cat $PLAN_FILE_JSON
-
-        sleep 3
-
-        jq -e . $PLAN_FILE_JSON
 
     - name: Configure State AWS Credentials
       if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}

--- a/action.yml
+++ b/action.yml
@@ -154,11 +154,6 @@ runs:
         echo "plan_file=$PLAN_FILE" >> $GITHUB_OUTPUT
         echo "plan_file_path=$PLAN_FILE_PATH" >> $GITHUB_OUTPUT
 
-    - shell: bash
-      run: |
-        echo "has_changes: ${{ steps.atmos-plan.outputs.has_changes }}"
-        echo "has_changes_json: ${{ fromJSON(steps.atmos-plan.outputs.has_changes) }}"
-
     - name: Configure State AWS Credentials
       if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}
       uses: aws-actions/configure-aws-credentials@v2.2.0
@@ -191,76 +186,76 @@ runs:
         tableName: ${{ inputs.terraform-state-table }}
         bucketName: ${{ inputs.terraform-state-bucket }}
 
-    # - name: Setup Infracost
-    #   if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
-    #   uses: infracost/actions/setup@v2
-    #   with:
-    #     api-key: ${{ inputs.infracost-api-key }}
+    - name: Setup Infracost
+      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
+      uses: infracost/actions/setup@v2
+      with:
+        api-key: ${{ inputs.infracost-api-key }}
 
-    # - name: Generate Infracost diff
-    #   if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
-    #   shell: bash
-    #   run: |
-    #     PLAN_FILE_JSON="${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json"
+    - name: Generate Infracost diff
+      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
+      shell: bash
+      run: |
+        PLAN_FILE_JSON="${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json"
 
-    #     cd ${{ inputs.component-path }}
-    #     terraform show -json $PLAN_FILE > $PLAN_FILE_JSON
+        cd ${{ inputs.component-path }}
+        terraform show -json $PLAN_FILE > $PLAN_FILE_JSON
 
-    #     infracost diff \
-    #       --path=$PLAN_FILE_JSON \
-    #       --format=diff \
-    #       --project-name ${{ inputs.stack }}-${{ inputs.component }} \
-    #       --out-file=/tmp/infracost.txt
-    #     infracost diff \
-    #       --path=$PLAN_FILE_JSON \
-    #       --format=json \
-    #       --project-name ${{ inputs.stack }}-${{ inputs.component }} \
-    #       --out-file=/tmp/infracost.json
+        infracost diff \
+          --path=$PLAN_FILE_JSON \
+          --format=diff \
+          --project-name ${{ inputs.stack }}-${{ inputs.component }} \
+          --out-file=/tmp/infracost.txt
+        infracost diff \
+          --path=$PLAN_FILE_JSON \
+          --format=json \
+          --project-name ${{ inputs.stack }}-${{ inputs.component }} \
+          --out-file=/tmp/infracost.json
 
-    # - if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) && fromJSON(inputs.debug) }}
-    #   shell: bash
-    #   run: |
-    #     cat ${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json
-    #     cat /tmp/infracost.txt
-    #     cat /tmp/infracost.json
+    - if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) && fromJSON(inputs.debug) }}
+      shell: bash
+      run: |
+        cat ${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json
+        cat /tmp/infracost.txt
+        cat /tmp/infracost.json
 
-    # - name: Set infracost variables
-    #   if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
-    #   id: infracost-diff
-    #   shell: bash
-    #   run: |
-    #     if [[ "${{ inputs.enable-infracost }}" == "true" ]]; then
-    #       INFRACOST_DIFF_TOTAL_MONTHLY_COST=$(cat /tmp/infracost.json | jq --raw-output .diffTotalMonthlyCost)
-    #       INFRACOST_DETAILS_DIFF_BREAKDOWN="$(cat /tmp/infracost.txt | base64 --wrap 0)"
-    #     else
-    #       INFRACOST_DIFF_TOTAL_MONTHLY_COST="0"
-    #       INFRACOST_DETAILS_DIFF_BREAKDOWN=""
-    #     fi
+    - name: Set infracost variables
+      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
+      id: infracost-diff
+      shell: bash
+      run: |
+        if [[ "${{ inputs.enable-infracost }}" == "true" ]]; then
+          INFRACOST_DIFF_TOTAL_MONTHLY_COST=$(cat /tmp/infracost.json | jq --raw-output .diffTotalMonthlyCost)
+          INFRACOST_DETAILS_DIFF_BREAKDOWN="$(cat /tmp/infracost.txt | base64 --wrap 0)"
+        else
+          INFRACOST_DIFF_TOTAL_MONTHLY_COST="0"
+          INFRACOST_DETAILS_DIFF_BREAKDOWN=""
+        fi
 
-    #     echo "infracost_details_diff_breakdown=$INFRACOST_DETAILS_DIFF_BREAKDOWN" >> "$GITHUB_OUTPUT"
-    #     echo "infracost_diff_total_monthly_cost=$INFRACOST_DIFF_TOTAL_MONTHLY_COST" >> "$GITHUB_OUTPUT"
+        echo "infracost_details_diff_breakdown=$INFRACOST_DETAILS_DIFF_BREAKDOWN" >> "$GITHUB_OUTPUT"
+        echo "infracost_diff_total_monthly_cost=$INFRACOST_DIFF_TOTAL_MONTHLY_COST" >> "$GITHUB_OUTPUT"
 
-    # - name: Post Plan
-    #   if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
-    #   id: post-plan
-    #   shell: bash
-    #   run: |
-    #     if [[ "${{ inputs.debug }}" == "true" ]]; then
-    #       LOG_LEVEL="DEBUG"
-    #     else
-    #       LOG_LEVEL="INFO"
-    #     fi
-    #     cd ${{ inputs.component-path }}
-    #     tfcmt \
-    #       --config "${{ github.action_path }}/config/atmos_github_summary.yaml" \
-    #       -owner "${{ github.repository_owner }}" \
-    #       -repo "${{ github.event.repository.name }}" \
-    #       -var "target:${{ inputs.stack }}-${{ inputs.component }}" \
-    #       -var "component:${{ inputs.component }}" \
-    #       -var "stack:${{ inputs.stack }}" \
-    #       -var "job:${{ github.job }}" \
-    #       -var "infracost_details_diff_breakdown:${{ steps.infracost-diff.outputs.infracost_details_diff_breakdown }}" \
-    #       -var "infracost_total_monthly_cost:${{ steps.infracost-diff.outputs.infracost_diff_total_monthly_cost }}" \
-    #       --output $GITHUB_STEP_SUMMARY \
-    #       --log-level $LOG_LEVEL \
-    #       plan -- terraform show ${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}
+    - name: Post Plan
+      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
+      id: post-plan
+      shell: bash
+      run: |
+        if [[ "${{ inputs.debug }}" == "true" ]]; then
+          LOG_LEVEL="DEBUG"
+        else
+          LOG_LEVEL="INFO"
+        fi
+        cd ${{ inputs.component-path }}
+        tfcmt \
+          --config "${{ github.action_path }}/config/atmos_github_summary.yaml" \
+          -owner "${{ github.repository_owner }}" \
+          -repo "${{ github.event.repository.name }}" \
+          -var "target:${{ inputs.stack }}-${{ inputs.component }}" \
+          -var "component:${{ inputs.component }}" \
+          -var "stack:${{ inputs.stack }}" \
+          -var "job:${{ github.job }}" \
+          -var "infracost_details_diff_breakdown:${{ steps.infracost-diff.outputs.infracost_details_diff_breakdown }}" \
+          -var "infracost_total_monthly_cost:${{ steps.infracost-diff.outputs.infracost_diff_total_monthly_cost }}" \
+          --output $GITHUB_STEP_SUMMARY \
+          --log-level $LOG_LEVEL \
+          plan -- terraform show ${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}

--- a/action.yml
+++ b/action.yml
@@ -162,7 +162,12 @@ runs:
         cd ${{ inputs.component-path }}
         terraform show -json "${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}" > $PLAN_FILE_JSON
 
+        sleep 3
+
         cat $PLAN_FILE_JSON
+
+        sleep 3
+
         jq . $PLAN_FILE_JSON
 
     - name: Configure State AWS Credentials

--- a/action.yml
+++ b/action.yml
@@ -160,7 +160,7 @@ runs:
         PLAN_FILE_JSON="${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json"
 
         cd ${{ inputs.component-path }}
-        terraform show -json "$PLAN_FILE_PATH/$PLAN_FILE" > $PLAN_FILE_JSON
+        terraform show -json "${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}" > $PLAN_FILE_JSON
 
         cat $PLAN_FILE_JSON
         jq . $PLAN_FILE_JSON

--- a/action.yml
+++ b/action.yml
@@ -103,6 +103,7 @@ runs:
         else
           echo "actions_enabled=false" >> $GITHUB_OUTPUT
         fi
+        echo "HAS_CHANGES=true" >> $GITHUB_ENV
 
     # setup-tfcmt requires this PATH update when running on self-hosted (amazon linux)
     # https://github.com/shmokmt/actions-setup-tfcmt/blob/main/action.yml#L11C1-L12C1
@@ -144,8 +145,20 @@ runs:
         echo "plan_file=$PLAN_FILE" >> $GITHUB_OUTPUT
         echo "plan_file_path=$PLAN_FILE_PATH" >> $GITHUB_OUTPUT
 
-    - name: Configure State AWS Credentials
+    - name: Plan Has Changes
       if: ${{ fromJSON(steps.settings.outputs.actions_enabled) }}
+      id: plan-state
+      shell: bash
+      run: |
+        terraform show -json "${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}" > "${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json"
+        HAS_CHANGES=$(jq '.resource_changes[] | select(.change.actions[] != "no-op")' "${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json")
+
+        if [[ "$HAS_CHANGES" == "" ]]; then
+          echo "HAS_CHANGES=false" >> $GITHUB_ENV
+        fi
+
+    - name: Configure State AWS Credentials
+      if: ${{ fromJSON(env.HAS_CHANGES) }}
       uses: aws-actions/configure-aws-credentials@v2.2.0
       with:
         aws-region: ${{ inputs.aws-region }}
@@ -154,7 +167,7 @@ runs:
         mask-aws-account-id: "no"
 
     - name: Store Plan
-      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) }}
+      if: ${{ fromJSON(env.HAS_CHANGES) }}
       uses: cloudposse/github-action-terraform-plan-storage@v1
       id: store-plan
       with:
@@ -166,7 +179,7 @@ runs:
         bucketName: ${{ inputs.terraform-state-bucket }}
 
     - name: Store Lockfile
-      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) }}
+      if: ${{ fromJSON(env.HAS_CHANGES) }}
       uses: cloudposse/github-action-terraform-plan-storage@v1
       with:
         action: storePlan
@@ -177,13 +190,13 @@ runs:
         bucketName: ${{ inputs.terraform-state-bucket }}
 
     - name: Setup Infracost
-      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(inputs.enable-infracost) }}
+      if: ${{ fromJSON(env.HAS_CHANGES) && fromJSON(inputs.enable-infracost) }}
       uses: infracost/actions/setup@v2
       with:
         api-key: ${{ inputs.infracost-api-key }}
 
     - name: Generate Infracost diff
-      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(inputs.enable-infracost) }}
+      if: ${{ fromJSON(env.HAS_CHANGES) && fromJSON(inputs.enable-infracost) }}
       shell: bash
       run: |
         PLAN_FILE="${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}"
@@ -203,7 +216,7 @@ runs:
           --project-name ${{ inputs.stack }}-${{ inputs.component }} \
           --out-file=/tmp/infracost.json
 
-    - if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(inputs.enable-infracost) && fromJSON(inputs.debug) }}
+    - if: ${{ fromJSON(env.HAS_CHANGES) && fromJSON(inputs.enable-infracost) && fromJSON(inputs.debug) }}
       shell: bash
       run: |
         cat ${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json
@@ -211,7 +224,7 @@ runs:
         cat /tmp/infracost.json
 
     - name: Set infracost variables
-      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) }}
+      if: ${{ fromJSON(env.HAS_CHANGES) }}
       id: infracost-diff
       shell: bash
       run: |
@@ -227,7 +240,7 @@ runs:
         echo "infracost_diff_total_monthly_cost=$INFRACOST_DIFF_TOTAL_MONTHLY_COST" >> "$GITHUB_OUTPUT"
 
     - name: Post Plan
-      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) }}
+      if: ${{ fromJSON(env.HAS_CHANGES) }}
       id: post-plan
       shell: bash
       run: |

--- a/action.yml
+++ b/action.yml
@@ -144,7 +144,7 @@ runs:
           -input=false -detailed-exitcode
         EXIT_CODE=$?
         if [[ "$EXIT_CODE" != "0" ]]; then
-          echo "HAS_CHANGES=false" >> $GITHUB_ENV
+          echo "HAS_CHANGES='false'" >> $GITHUB_ENV
         fi
         echo "plan_file=$PLAN_FILE" >> $GITHUB_OUTPUT
         echo "plan_file_path=$PLAN_FILE_PATH" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -145,8 +145,8 @@ runs:
           -out=$PLAN_FILE_PATH/$PLAN_FILE \
           -input=false -detailed-exitcode
         
-        PLAN_FILE_JSON="${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json"
-        terraform show -json "${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}" > $PLAN_FILE_JSON
+        PLAN_FILE_JSON="$PLAN_FILE_PATH/$PLAN_FILE.json"
+        terraform show -json "$PLAN_FILE_PATH/$PLAN_FILE" > $PLAN_FILE_JSON
 
         cat $PLAN_FILE_JSON
         jq . $PLAN_FILE_JSON

--- a/action.yml
+++ b/action.yml
@@ -14,10 +14,10 @@ inputs:
   component-path:
     description: "The path to the base component. Atmos defines this value as component_path."
     required: true
-  plan-file-suffix:
-    description: "Suffix that is used to build plan file name. Default: ''"
+  plan-file:
+    description: "Full name of the plan-file to use. If not set plan-file name will be built by pattern '<stack>-<component>-<github.sha>'. Default: ''"
     required: false
-    default: ""
+    default: ''
   terraform-plan-role:
     description: "The AWS role to be used to plan Terraform."
     required: true
@@ -131,12 +131,11 @@ runs:
       id: atmos-plan
       shell: bash
       run: |
-        SUFFIX="${{ github.sha }}"
-        if [ "${{ inputs.plan-file-suffix }}" != "" ]; then
-          SUFFIX="${{ inputs.plan-file-suffix }}"
+        PLAN_FILE=$(echo "${{ inputs.stack }}-${{ inputs.component }}-${{ github.sha }}.planfile" | sed 's#/#_#g') 
+        if [ "${{ inputs.plan-file }}" != "" ]; then
+          PLAN_FILE="${{ inputs.plan-file }}"
         fi
 
-        PLAN_FILE=$(echo "${{ inputs.stack }}-${{ inputs.component }}-${SUFFIX}.planfile" | sed 's#/#_#g') 
         PLAN_FILE_PATH=$(pwd)
         ATMOS_BASE_PATH=$GITHUB_WORKSPACE atmos terraform plan ${{ inputs.component }} \
           --stack ${{ inputs.stack }} \

--- a/action.yml
+++ b/action.yml
@@ -55,6 +55,13 @@ inputs:
       not supplied by the user. When running this action on github.com, the default value is sufficient. When running on
       GHES, you can pass a personal access token for github.com if you are experiencing rate limiting.
     default: ${{ github.server_url == 'https://github.com' && github.token || '' }}
+outputs:
+  plan-file-path:
+    description: Plan File
+    value: ${{ steps.atmos-plan.outputs.plan_file_path }}
+  plan-file:
+    description: Plan File
+    value: ${{ steps.atmos-plan.outputs.plan_file }}
 
 runs:
   using: "composite"

--- a/action.yml
+++ b/action.yml
@@ -15,9 +15,9 @@ inputs:
     description: "The path to the base component. Atmos defines this value as component_path."
     required: true
   plan-file-suffix:
-    description: "Suffix that is used to build plan file name. Default: '${{ github.sha }}'"
-    required: true
-    default: "${{ github.sha }}"
+    description: "Suffix that is used to build plan file name. Default: ''"
+    required: false
+    default: ""
   terraform-plan-role:
     description: "The AWS role to be used to plan Terraform."
     required: true
@@ -131,7 +131,12 @@ runs:
       id: atmos-plan
       shell: bash
       run: |
-        PLAN_FILE=$(echo "${{ inputs.stack }}-${{ inputs.component }}-${{ inputs.plan-file-suffix }}.planfile" | sed 's#/#_#g') 
+        SUFFIX="${{ github.sha }}"
+        if [ "$variable" != "" ]; then
+          SUFFIX="${{ inputs.plan-file-suffix }}"
+        fi
+
+        PLAN_FILE=$(echo "${{ inputs.stack }}-${{ inputs.component }}-${SUFFIX}.planfile" | sed 's#/#_#g') 
         PLAN_FILE_PATH=$(pwd)
         ATMOS_BASE_PATH=$GITHUB_WORKSPACE atmos terraform plan ${{ inputs.component }} \
           --stack ${{ inputs.stack }} \

--- a/action.yml
+++ b/action.yml
@@ -144,13 +144,13 @@ runs:
           -input=false -detailed-exitcode
         EXIT_CODE=$?
         if [[ "$EXIT_CODE" != "0" ]]; then
-          echo "HAS_CHANGES='false'" >> $GITHUB_ENV
+          echo "has_changes='true'" >> $GITHUB_OUTPUT
         fi
         echo "plan_file=$PLAN_FILE" >> $GITHUB_OUTPUT
         echo "plan_file_path=$PLAN_FILE_PATH" >> $GITHUB_OUTPUT
 
     - name: Configure State AWS Credentials
-      if: env.HAS_CHANGES == 'true'
+      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}
       uses: aws-actions/configure-aws-credentials@v2.2.0
       with:
         aws-region: ${{ inputs.aws-region }}
@@ -159,7 +159,7 @@ runs:
         mask-aws-account-id: "no"
 
     - name: Store Plan
-      if: env.HAS_CHANGES == 'true'
+      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}
       uses: cloudposse/github-action-terraform-plan-storage@v1
       id: store-plan
       with:
@@ -171,7 +171,7 @@ runs:
         bucketName: ${{ inputs.terraform-state-bucket }}
 
     - name: Store Lockfile
-      if: env.HAS_CHANGES == 'true'
+      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) }}
       uses: cloudposse/github-action-terraform-plan-storage@v1
       with:
         action: storePlan
@@ -182,13 +182,13 @@ runs:
         bucketName: ${{ inputs.terraform-state-bucket }}
 
     - name: Setup Infracost
-      if: ${{ env.HAS_CHANGES == 'true' && fromJSON(inputs.enable-infracost) }}
+      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
       uses: infracost/actions/setup@v2
       with:
         api-key: ${{ inputs.infracost-api-key }}
 
     - name: Generate Infracost diff
-      if: ${{ env.HAS_CHANGES == 'true' && fromJSON(inputs.enable-infracost) }}
+      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
       shell: bash
       run: |
         PLAN_FILE_JSON="${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json"
@@ -207,7 +207,7 @@ runs:
           --project-name ${{ inputs.stack }}-${{ inputs.component }} \
           --out-file=/tmp/infracost.json
 
-    - if: ${{ env.HAS_CHANGES == 'true' && fromJSON(inputs.enable-infracost) && fromJSON(inputs.debug) }}
+    - if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) && fromJSON(inputs.debug) }}
       shell: bash
       run: |
         cat ${{ steps.atmos-plan.outputs.plan_file_path }}/${{ steps.atmos-plan.outputs.plan_file }}.json
@@ -215,7 +215,7 @@ runs:
         cat /tmp/infracost.json
 
     - name: Set infracost variables
-      if: env.HAS_CHANGES == 'true'
+      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
       id: infracost-diff
       shell: bash
       run: |
@@ -231,7 +231,7 @@ runs:
         echo "infracost_diff_total_monthly_cost=$INFRACOST_DIFF_TOTAL_MONTHLY_COST" >> "$GITHUB_OUTPUT"
 
     - name: Post Plan
-      if: env.HAS_CHANGES == 'true'
+      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(steps.atmos-plan.outputs.has_changes) && fromJSON(inputs.enable-infracost) }}
       id: post-plan
       shell: bash
       run: |

--- a/action.yml
+++ b/action.yml
@@ -155,6 +155,9 @@ runs:
           echo "has_changes=true" >> $GITHUB_OUTPUT
         fi
 
+        echo "all outputs: "
+        echo $GITHUB_OUTPUT
+
         echo "plan_file=$PLAN_FILE" >> $GITHUB_OUTPUT
         echo "plan_file_path=$PLAN_FILE_PATH" >> $GITHUB_OUTPUT
 

--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ inputs:
   plan-file-suffix:
     description: "Suffix that is used to build plan file name. Default: '${{ github.sha }}'"
     required: true
-    default: ${{ github.sha }}
+    default: "${{ github.sha }}"
   terraform-plan-role:
     description: "The AWS role to be used to plan Terraform."
     required: true

--- a/config/atmos_github_summary.yaml
+++ b/config/atmos_github_summary.yaml
@@ -13,7 +13,7 @@ templates:
     ## :x: Plan Failed for `{{.Vars.component}}` in `{{.Vars.stack}}`!
     {{ end }}
     {{- if eq .ExitCode 0 }}
-    ## Plan Succeeded for `{{.Vars.component}}` in `{{.Vars.stack}}`
+    ## Changes Found for `{{.Vars.component}}` in `{{.Vars.stack}}`
     
     {{ if .CreatedResources}}[![create](https://shields.io/badge/PLAN-CREATE-success?style=for-the-badge)](#user-content-create-{{.Vars.stack}}-{{.Vars.component}}){{ end }}
     {{- if .UpdatedResources }} [![change](https://shields.io/badge/PLAN-CHANGE-important?style=for-the-badge)](#user-content-change-{{.Vars.stack}}-{{.Vars.component}}){{ end }}

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -11,6 +11,7 @@
 | debug | Enable action debug mode. Default: 'false' | false | false |
 | enable-infracost | Whether to enable infracost summary. Requires secret `infracost-api-key` to be specified. Default: 'false | false | false |
 | infracost-api-key | Infracost API key | N/A | false |
+| plan-id | Suffix that will be used for plan file name to uniquely identify it. Default: github.sha | ${{ github.sha }} | true |
 | stack | The stack name for the given component. | N/A | true |
 | terraform-plan-role | The AWS role to be used to plan Terraform. | N/A | true |
 | terraform-state-bucket | The S3 Bucket where the planfiles are stored. | N/A | true |
@@ -20,4 +21,9 @@
 | token | Used to pull node distributions for Atmos from Cloud Posse's GitHub repository. Since there's a default, this is typically not supplied by the user. When running this action on github.com, the default value is sufficient. When running on GHES, you can pass a personal access token for github.com if you are experiencing rate limiting. | ${{ github.server\_url == 'https://github.com' && github.token \|\| '' }} | false |
 
 
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| has-changes | Has Changes |
 <!-- markdownlint-restore -->


### PR DESCRIPTION
## what

Added `input.plan-id` and `output.has-changes`

## why

These inputs and outputs are required for drift detection action and workflow.

- `input.plan-id` is a suffix that will uniquely distinguish a particular plan
- `output.has-changes` is used in drift detection workflow and indicates whether the plan has changed or not

## references

