### PR TITLE
Fix rare pipeline failing

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -175,31 +175,33 @@ runs:
       run: |
         set +e
         
-        TERRAFORM_OUTPUT=$( \
-          tfcmt \
-          --config ${{ github.action_path }}/config/summary.yaml \
-          -owner "${{ github.repository_owner }}" \
-          -repo "${{ github.event.repository.name }}" \
-          -var "target:${{ steps.vars.outputs.component_slug }}" \
-          -var "component:${{ inputs.component }}" \
-          -var "componentPath:${{ steps.vars.outputs.component_path }}" \
-          -var "commitSHA:${{ inputs.sha }}" \
-          -var "stack:${{ inputs.stack }}" \
-          -var "job:${{ github.job }}" \
-          -var "logoImage:${{ inputs.branding-logo-image }}" \
-          -var "logoUrl:${{ inputs.branding-logo-url }}" \
-          -var "infracost_enabled:${{ steps.config.outputs.enable-infracost }}" \
-          -var "driftModeEnabled:${{ inputs.drift-detection-mode-enabled }}" \
-          --output ${{ steps.vars.outputs.summary_file }} \
-          --log-level $([[ "${{ inputs.debug }}" == "true" ]] && echo "DEBUG" || echo "INFO") \
-          plan -- \
-            atmos terraform plan ${{ inputs.component }} \
-            --stack ${{ inputs.stack }} \
-            -out="${{ steps.vars.outputs.plan_file }}" \
-            -lock=false \
-            -input=false \
-            -no-color
-        )
+        TERRAFORM_OUTPUT_FILE="./terraform-${GITHUB_RUN_ID}-output.txt"
+
+        tfcmt \
+        --config ${{ github.action_path }}/config/summary.yaml \
+        -owner "${{ github.repository_owner }}" \
+        -repo "${{ github.event.repository.name }}" \
+        -var "target:${{ steps.vars.outputs.component_slug }}" \
+        -var "component:${{ inputs.component }}" \
+        -var "componentPath:${{ steps.vars.outputs.component_path }}" \
+        -var "commitSHA:${{ inputs.sha }}" \
+        -var "stack:${{ inputs.stack }}" \
+        -var "job:${{ github.job }}" \
+        -var "logoImage:${{ inputs.branding-logo-image }}" \
+        -var "logoUrl:${{ inputs.branding-logo-url }}" \
+        -var "infracost_enabled:${{ steps.config.outputs.enable-infracost }}" \
+        -var "driftModeEnabled:${{ inputs.drift-detection-mode-enabled }}" \
+        --output ${{ steps.vars.outputs.summary_file }} \
+        --log-level $([[ "${{ inputs.debug }}" == "true" ]] && echo "DEBUG" || echo "INFO") \
+        plan -- \
+          atmos terraform plan ${{ inputs.component }} \
+          --stack ${{ inputs.stack }} \
+          -out="${{ steps.vars.outputs.plan_file }}" \
+          -lock=false \
+          -input=false \
+          -no-color \
+        &> ${TERRAFORM_OUTPUT_FILE}
+
         TERRAFORM_RESULT=$?
 
         set -e
@@ -220,7 +222,7 @@ runs:
         HAS_NO_CHANGES=false
         HAS_ERROR=false
         if [[ "${TERRAFORM_RESULT}" == "0" ]]; then
-          if echo "$TERRAFORM_OUTPUT" | grep -q '^No changes. Your infrastructure matches the configuration.'; then
+          if grep -q '^No changes. Your infrastructure matches the configuration.' ${TERRAFORM_OUTPUT_FILE} ; then
             echo "No changes found"
             HAS_NO_CHANGES=true
           else

--- a/action.yml
+++ b/action.yml
@@ -240,6 +240,8 @@ runs:
         echo "error=${HAS_ERROR}" >> $GITHUB_OUTPUT
 
         echo "result=${TERRAFORM_RESULT}" >> $GITHUB_OUTPUT
+        
+        rm -f ${TERRAFORM_OUTPUT_FILE}
 
     - name: Convert PLANFILE to JSON
       if: ${{ steps.atmos-plan.outputs.changes == 'true' }}


### PR DESCRIPTION
## what

* Get rid of pipeline in grep terraform output command

## why

* In infrequent cases the pipeline fails with a message

```
No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration
/runner/_work/_temp/df1589d2-68cc-40ec-a0d6-3622534dcc12.sh: line 48: echo: write error: Broken pipe
and found no differences, so no changes are needed.Found changes
```

That led to a summary with `no-changes` and wrong metadata JSON, leading to issues with apply and drift detection workflows.

You can find the example here https://github.com/cloudposse/infra-test/actions/runs/7398797169/job/20128803191

## References
* [Why am I getting "cat: write error: Broken pipe" rarely and not always](https://stackoverflow.com/questions/49664991/why-am-i-getting-cat-write-error-broken-pipe-rarely-and-not-always)
