### PR TITLE
fix: assume IAM role before running `cloudposse/github-action-atmos-get-setting`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -107,6 +107,15 @@ runs:
           suzuki-shunsuke/tfcmt:
             tag: v4.11.0  
 
+    - name: Configure Plan AWS Credentials
+      if: ${{ fromJson(steps.component.outputs.settings).enabled }}
+      uses: aws-actions/configure-aws-credentials@v4.0.2
+      with:
+        aws-region: ${{ steps.config.outputs.aws-region }}
+        role-to-assume: ${{ steps.config.outputs.terraform-plan-role }}
+        role-session-name: "atmos-terraform-plan-gitops"
+        mask-aws-account-id: "no"
+
     - name: Get atmos settings
       uses: cloudposse/github-action-atmos-get-setting@v1
       id: component
@@ -171,15 +180,6 @@ runs:
         echo "summary_file=${SUMMARY_FILE}" >> $GITHUB_OUTPUT
         echo "step_summary_file=${STEP_SUMMARY_FILE}" >> $GITHUB_OUTPUT
         echo "issue_file=${ISSUE_SUMMARY_FILE}" >> $GITHUB_OUTPUT
-
-    - name: Configure Plan AWS Credentials
-      if: ${{ fromJson(steps.component.outputs.settings).enabled }}
-      uses: aws-actions/configure-aws-credentials@v4.0.2
-      with:
-        aws-region: ${{ steps.config.outputs.aws-region }}
-        role-to-assume: ${{ steps.config.outputs.terraform-plan-role }}
-        role-session-name: "atmos-terraform-plan-gitops"
-        mask-aws-account-id: "no"
 
     - name: Cache .terraform
       id: cache

--- a/action.yml
+++ b/action.yml
@@ -108,7 +108,6 @@ runs:
             tag: v4.11.0  
 
     - name: Configure Plan AWS Credentials
-      if: ${{ fromJson(steps.component.outputs.settings).enabled }}
       uses: aws-actions/configure-aws-credentials@v4.0.2
       with:
         aws-region: ${{ steps.config.outputs.aws-region }}


### PR DESCRIPTION
## what

* assume IAM role before running `cloudposse/github-action-atmos-get-setting`

## why

As of atmos `1.86.2`, when `atmos.Component` began actually retrieving the TF state, it broke `cloudposse/github-action-atmos-affected-stacks` which we resolved as part of [this release](https://github.com/cloudposse/github-action-atmos-affected-stacks/releases/tag/v3.4.0) of the aforementioned action. We just had the action assume the IAM role, and that was it. However in cases where this function is used, appropriate IAM credentials to also be a requirement for `cloudposse/github-action-atmos-get-setting`:

```bash
> Run cloudposse/github-action-atmos-get-setting@v1
template: all-atmos-sections:163:26: executing "all-atmos-sections" at <atmos.Component>: error calling Component: exit status 1

Error: error configuring S3 Backend: IAM Role (arn:aws:iam::xxxxxxxxxxxx:role/xxxx-core-gbl-root-tfstate) cannot be assumed.

There are a number of possible causes of this - the most common are:
  * The credentials used in order to assume the role are invalid
  * The credentials do not have appropriate permission to assume the role
  * The role ARN is not valid

Error: NoCredentialProviders: no valid providers in chain. Deprecated.
	For verbose messaging see aws.Config.CredentialsChainVerboseErrors
```

## references

https://github.com/cloudposse/atmos/releases/tag/v1.86.2

