### PR TITLE
fix: replace context with default var

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -199,7 +199,7 @@ runs:
         TERRAFORM_OUTPUT_FILE="./terraform-${GITHUB_RUN_ID}-output.txt"
 
         tfcmt \
-        --config ${{ github.action_path }}/config/summary.yaml \
+        --config ${GITHUB_ACTION_PATH}/config/summary.yaml \
         -owner "${{ github.repository_owner }}" \
         -repo "${{ github.event.repository.name }}" \
         -var "target:${{ steps.vars.outputs.component_slug }}" \


### PR DESCRIPTION
## what
- Replace context with default variable

## why
- When using container within GitHub Actions, context value is incorrect. Default variable value remains correct.
- As github.action_path is used during step execution (within runner), it can be replaced by default variable.

## references
* https://github.com/cloudposse/github-action-atmos-affected-stacks/pull/52
* There are more reported issues showing this problem in various scenarios, for instance [this one](https://github.com/actions/runner/issues/716#issuecomment-1494213926)
