### PR TITLE
Google backend

### DIFF
--- a/README.yaml
+++ b/README.yaml
@@ -44,20 +44,24 @@ references:
 usage: |-
   ### Prerequisites
 
-  This GitHub Action requires AWS access for two different purposes. This action will attempt to first run `terraform plan` against a given component and 
-  then will use another role to save that given Terraform Plan to an S3 Bucket with metadata in a DynamoDB table. We recommend configuring 
-  [OpenID Connect with AWS](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services) 
-  to allow GitHub to assume roles in AWS and then deploying both a Terraform Plan role and a Terraform State role. 
-  For Cloud Posse documentation on setting up GitHub OIDC, see our [`github-oidc-provider` component](https://docs.cloudposse.com/components/library/aws/github-oidc-provider/).
+  This GitHub Action requires cloud provider access for two different purposes. This action will attempt to first run `terraform plan` against a given component and
+  then will use credentials to save that given Terraform Plan to cloud storage with metadata.
 
-  In order to store Terraform State, we configure an S3 Bucket to store plan files and a DynamoDB table to track plan metadata. Both will need to be deployed before running
-  this action. For more on setting up those components, see the `gitops` component (__documentation pending__). This action will then use the [github-action-terraform-plan-storage](https://github.com/cloudposse/github-action-terraform-plan-storage) action to update these resources.
+  For AWS, we recommend configuring [OpenID Connect with AWS](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services)
+  to allow GitHub to assume roles in AWS and then deploying both a Terraform Plan role and a Terraform State role.
+  For Cloud Posse documentation on setting up GitHub OIDC with AWS, see our [`github-oidc-provider` component](https://docs.cloudposse.com/components/library/aws/github-oidc-provider/).
+
+  For Google Cloud, we recommend configuring [Workload Identity Federation](https://cloud.google.com/iam/docs/workload-identity-federation-with-GitHub-actions)
+  to allow GitHub Actions to authenticate with Google Cloud services. This will enable access to Google Cloud Storage for plan files and Firestore for metadata storage.
+
+  For AWS storage, we configure an S3 Bucket to store plan files and a DynamoDB table to track plan metadata. For Google Cloud storage, we use Google Cloud Storage buckets for plan files and Firestore for metadata. These resources will need to be deployed before running this action. For more on setting up those components, see the `gitops` component (__documentation pending__). This action will then use the [github-action-terraform-plan-storage](https://github.com/cloudposse/github-action-terraform-plan-storage) action to update these resources.
 
   ### Config
 
   The action expects the atmos configuration file `atmos.yaml` to be present in the repository.
   The config should have the following structure:
   
+  #### AWS
   ```yaml
   integrations:
     github:
@@ -76,6 +80,23 @@ usage: |-
         matrix:
           sort-by: .stack_slug
           group-by: .stack_slug | split("-") | [.[0], .[2]] | join("-")
+  ```
+
+  #### Google Cloud
+  ```yaml
+  integrations:
+    github:
+      gitops:
+        ...
+        artifact-storage:
+          ...
+          bucket: cptest-core-ue2-auto-gitops
+          google-service-account: terraform@project-id.iam.gserviceaccount.com
+          google-workload-identity-provider: projects/project-id/locations/global/workloadIdentityPools/github-actions/providers/github-provider
+          google-project-id: cptest-core-ue2-auto-gitops
+          google-firestore-database-name: cptest-core-ue2-auto-gitops
+          google-firestore-collection-name: terraform-plan-storage
+
   ```
   
   > [!IMPORTANT]

--- a/action.yml
+++ b/action.yml
@@ -88,12 +88,12 @@ runs:
         token: ${{ inputs.token }}
         install-wrapper: false
 
-    - name: Install OpenTofu
-      uses: cloudposse-github-actions/install-gh-releases@v1
-      with:
-        cache: true
-        config: |-
-          opentofu/opentofu: latest
+    # - name: Install OpenTofu
+    #   uses: cloudposse-github-actions/install-gh-releases@v1
+    #   with:
+    #     cache: true
+    #     config: |-
+    #       opentofu/opentofu: latest
 
     - name: Get atmos settings
       id: atmos-settings

--- a/action.yml
+++ b/action.yml
@@ -300,7 +300,7 @@ runs:
 
     - name: Store New Plan (Google)
       if: ${{ steps.atmos-plan.outputs.error == 'false' && steps.config.outputs.backend == 'google' }}
-      uses: shirkevich/github-action-terraform-plan-storage@c6f8f7e0fdb4f8ed21ebceec068a68117fb9114f
+      uses: shirkevich/github-action-terraform-plan-storage@935c724bfe991c8b12260981f37118063cd5f400
       id: store-plan-google
       with:
         action: storePlan
@@ -328,7 +328,7 @@ runs:
 
     - name: Store Lockfile for New Plan (Google)
       if: ${{ steps.atmos-plan.outputs.error == 'false' && steps.config.outputs.backend == 'google' }}
-      uses: shirkevich/github-action-terraform-plan-storage@c6f8f7e0fdb4f8ed21ebceec068a68117fb9114f
+      uses: shirkevich/github-action-terraform-plan-storage@935c724bfe991c8b12260981f37118063cd5f400
       with:
         action: storePlan
         commitSHA: ${{ inputs.sha }}

--- a/action.yml
+++ b/action.yml
@@ -300,7 +300,7 @@ runs:
 
     - name: Store New Plan (Google)
       if: ${{ steps.atmos-plan.outputs.error == 'false' && steps.config.outputs.backend == 'google' }}
-      uses: shirkevich/github-action-terraform-plan-storage@google-cloud-backend
+      uses: shirkevich/github-action-terraform-plan-storage@google-cloud-backend?v=1
       id: store-plan-google
       with:
         action: storePlan
@@ -328,7 +328,7 @@ runs:
 
     - name: Store Lockfile for New Plan (Google)
       if: ${{ steps.atmos-plan.outputs.error == 'false' && steps.config.outputs.backend == 'google' }}
-      uses: shirkevich/github-action-terraform-plan-storage@google-cloud-backend
+      uses: shirkevich/github-action-terraform-plan-storage@google-cloud-backend?v=1
       with:
         action: storePlan
         commitSHA: ${{ inputs.sha }}

--- a/action.yml
+++ b/action.yml
@@ -88,7 +88,7 @@ runs:
         echo "enable-infracost=$(atmos describe config -f json | jq -r '.integrations.github.gitops["infracost-enabled"]')" >> $GITHUB_OUTPUT        
         echo "backend=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"].backend')" >> $GITHUB_OUTPUT
         echo "aws-region=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"].region')" >> $GITHUB_OUTPUT
-        echo "gcp-project-id=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"].gcp-project-id')" >> $GITHUB_OUTPUT
+        echo "gcp-project-id=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"]."gcp-project-id"')" >> $GITHUB_OUTPUT
         echo "terraform-state-role=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"].role')" >> $GITHUB_OUTPUT
         echo "terraform-state-table=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"].table')" >> $GITHUB_OUTPUT
         echo "terraform-state-bucket=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"].bucket')" >> $GITHUB_OUTPUT        

--- a/action.yml
+++ b/action.yml
@@ -300,7 +300,7 @@ runs:
 
     - name: Store New Plan (Google)
       if: ${{ steps.atmos-plan.outputs.error == 'false' && steps.config.outputs.backend == 'google' }}
-      uses: shirkevich/github-action-terraform-plan-storage@d044efc50beac1549e9a088ef7ec63e441ed56f6
+      uses: shirkevich/github-action-terraform-plan-storage@google-cloud-backend
       id: store-plan-google
       with:
         action: storePlan
@@ -329,7 +329,7 @@ runs:
 
     - name: Store Lockfile for New Plan (Google)
       if: ${{ steps.atmos-plan.outputs.error == 'false' && steps.config.outputs.backend == 'google' }}
-      uses: shirkevich/github-action-terraform-plan-storage@d044efc50beac1549e9a088ef7ec63e441ed56f6
+      uses: shirkevich/github-action-terraform-plan-storage@google-cloud-backend
       with:
         action: storePlan
         commitSHA: ${{ inputs.sha }}

--- a/action.yml
+++ b/action.yml
@@ -64,9 +64,6 @@ outputs:
     description: "Summary"
     value: "${{ steps.summary.outputs.result }}"
 
-env:
-  ACTIONS_STEP_DEBUG: true
-
 runs:
   using: "composite"
   steps:
@@ -87,13 +84,6 @@ runs:
         atmos-version: ${{ inputs.atmos-version }}
         token: ${{ inputs.token }}
         install-wrapper: false
-
-    # - name: Install OpenTofu
-    #   uses: cloudposse-github-actions/install-gh-releases@v1
-    #   with:
-    #     cache: true
-    #     config: |-
-    #       opentofu/opentofu: latest
 
     - name: Get atmos settings
       id: atmos-settings

--- a/action.yml
+++ b/action.yml
@@ -300,7 +300,7 @@ runs:
 
     - name: Store New Plan (Google)
       if: ${{ steps.atmos-plan.outputs.error == 'false' && steps.config.outputs.backend == 'google' }}
-      uses: shirkevich/github-action-terraform-plan-storage@8cc27bfcbf945d0e54ae90b9357462ac528f781a
+      uses: shirkevich/github-action-terraform-plan-storage@3005198d4d647872ca19dcb1734083db9758462a
       id: store-plan-google
       with:
         action: storePlan
@@ -328,7 +328,7 @@ runs:
 
     - name: Store Lockfile for New Plan (Google)
       if: ${{ steps.atmos-plan.outputs.error == 'false' && steps.config.outputs.backend == 'google' }}
-      uses: shirkevich/github-action-terraform-plan-storage@8cc27bfcbf945d0e54ae90b9357462ac528f781a
+      uses: shirkevich/github-action-terraform-plan-storage@3005198d4d647872ca19dcb1734083db9758462a
       with:
         action: storePlan
         commitSHA: ${{ inputs.sha }}

--- a/action.yml
+++ b/action.yml
@@ -312,7 +312,7 @@ runs:
         gcpCredentials: ${{ inputs.gcp-credentials }}
         gcpProjectId: ${{ steps.config.outputs.gcp-project-id }}
         metadataRepositoryType: firestore
-        firestoreCollectionName: ${{ steps.config.outputs.terraform-state-table }}
+        tableName: ${{ steps.config.outputs.terraform-state-table }}
 
     - name: Store Lockfile for New Plan (AWS)
       if: ${{ steps.atmos-plan.outputs.error == 'false' && steps.config.outputs.backend == 'aws' }}
@@ -339,7 +339,7 @@ runs:
         gcpCredentials: ${{ inputs.gcp-credentials }}
         gcpProjectId: ${{ steps.config.outputs.gcp-project-id }}
         metadataRepositoryType: firestore
-
+        tableName: ${{ steps.config.outputs.terraform-state-table }}
     - name: Setup Infracost
       if: ${{ steps.config.outputs.enable-infracost == 'true' && steps.atmos-plan.outputs.changes == 'true' }}
       uses: infracost/actions/setup@v3

--- a/action.yml
+++ b/action.yml
@@ -314,11 +314,11 @@ runs:
         component: ${{ inputs.component }}
         stack: ${{ inputs.stack }}
         planRepositoryType: gcs
-        gcpProjectId: ${{ steps.config.outputs.gcp-project-id }}
         metadataRepositoryType: firestore
-        tableName: ${{ steps.config.outputs.terraform-state-table }}
         bucketName: ${{ steps.config.outputs.terraform-state-bucket }}
-        databaseId: ${{ steps.config.outputs.google-firestore-database-id }}
+        gcpProjectId: ${{ steps.config.outputs.gcp-project-id }}
+        gcpFirestoreDatabaseName: ${{ steps.config.outputs.google-firestore-database-name }}
+        gcpFirestoreCollectionName: ${{ steps.config.outputs.google-firestore-collection-name }}
 
     - name: Store Lockfile for New Plan (AWS)
       if: ${{ steps.atmos-plan.outputs.error == 'false' && steps.config.outputs.backend == 'aws' }}
@@ -342,11 +342,12 @@ runs:
         component: ${{ inputs.component }}
         stack: ${{ inputs.stack }}-lockfile
         planRepositoryType: gcs
-        gcpProjectId: ${{ steps.config.outputs.gcp-project-id }}
         metadataRepositoryType: firestore
-        tableName: ${{ steps.config.outputs.terraform-state-table }}
         bucketName: ${{ steps.config.outputs.terraform-state-bucket }}
-        databaseId: ${{ steps.config.outputs.google-firestore-database-id }}
+        gcpProjectId: ${{ steps.config.outputs.google-project-id }}
+        gcpFirestoreDatabaseName: ${{ steps.config.outputs.google-firestore-database-name }}
+        gcpFirestoreCollectionName: ${{ steps.config.outputs.google-firestore-collection-name }}
+
     - name: Setup Infracost
       if: ${{ steps.config.outputs.enable-infracost == 'true' && steps.atmos-plan.outputs.changes == 'true' }}
       uses: infracost/actions/setup@v3

--- a/action.yml
+++ b/action.yml
@@ -51,6 +51,9 @@ inputs:
       not supplied by the user. When running this action on github.com, the default value is sufficient. When running on
       GHES, you can pass a personal access token for github.com if you are experiencing rate limiting.
     default: ${{ github.server_url == 'https://github.com' && github.token || '' }}
+  gcp-credentials:
+    description: "Google Cloud service account key JSON"
+    required: false
 outputs:
   summary:
     description: "Summary"
@@ -83,7 +86,9 @@ runs:
         echo "opentofu-version=$(atmos describe config -f json | jq -r '.integrations.github.gitops["opentofu-version"]')" >> $GITHUB_OUTPUT
         echo "terraform-version=$(atmos describe config -f json | jq -r '.integrations.github.gitops["terraform-version"]')" >> $GITHUB_OUTPUT
         echo "enable-infracost=$(atmos describe config -f json | jq -r '.integrations.github.gitops["infracost-enabled"]')" >> $GITHUB_OUTPUT        
+        echo "backend=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"].backend')" >> $GITHUB_OUTPUT
         echo "aws-region=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"].region')" >> $GITHUB_OUTPUT
+        echo "gcp-project-id=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"].gcp-project-id')" >> $GITHUB_OUTPUT
         echo "terraform-state-role=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"].role')" >> $GITHUB_OUTPUT
         echo "terraform-state-table=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"].table')" >> $GITHUB_OUTPUT
         echo "terraform-state-bucket=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"].bucket')" >> $GITHUB_OUTPUT        
@@ -108,6 +113,7 @@ runs:
             tag: v4.11.0  
 
     - name: Configure Plan AWS Credentials
+      if: ${{ steps.config.outputs.backend == 'aws' }}
       uses: aws-actions/configure-aws-credentials@v4.0.2
       with:
         aws-region: ${{ steps.config.outputs.aws-region }}
@@ -273,10 +279,10 @@ runs:
         role-session-name: "atmos-terraform-state-gitops"
         mask-aws-account-id: "no"
 
-    - name: Store New Plan
-      if: ${{ steps.atmos-plan.outputs.error == 'false' }}
+    - name: Store New Plan (AWS)
+      if: ${{ steps.atmos-plan.outputs.error == 'false' && steps.config.outputs.backend == 'aws' }}
       uses: cloudposse/github-action-terraform-plan-storage@v1
-      id: store-plan
+      id: store-plan-aws
       with:
         action: storePlan
         commitSHA: ${{ inputs.sha }}
@@ -286,8 +292,24 @@ runs:
         tableName: ${{ steps.config.outputs.terraform-state-table }}
         bucketName: ${{ steps.config.outputs.terraform-state-bucket }}
 
-    - name: Store Lockfile for New Plan
-      if: ${{ steps.atmos-plan.outputs.error == 'false' }}
+    - name: Store New Plan (Google)
+      if: ${{ steps.atmos-plan.outputs.error == 'false' && steps.config.outputs.backend == 'google' }}
+      uses: shirkevich/github-action-terraform-plan-storage@google-cloud-backend
+      id: store-plan-google
+      with:
+        action: storePlan
+        commitSHA: ${{ inputs.sha }}
+        planPath: ${{ steps.vars.outputs.plan_file }}
+        component: ${{ inputs.component }}
+        stack: ${{ inputs.stack }}
+        planRepositoryType: gcs
+        gcpCredentials: ${{ inputs.gcp-credentials }}
+        gcpProjectId: ${{ steps.config.outputs.gcp-project-id }}
+        metadataRepositoryType: firestore
+        firestoreCollectionName: ${{ steps.config.outputs.terraform-state-table }}
+
+    - name: Store Lockfile for New Plan (AWS)
+      if: ${{ steps.atmos-plan.outputs.error == 'false' && steps.config.outputs.backend == 'aws' }}
       uses: cloudposse/github-action-terraform-plan-storage@v1
       with:
         action: storePlan
@@ -297,6 +319,20 @@ runs:
         stack: ${{ inputs.stack }}-lockfile
         tableName: ${{ steps.config.outputs.terraform-state-table }}
         bucketName: ${{ steps.config.outputs.terraform-state-bucket }}
+
+    - name: Store Lockfile for New Plan (Google)
+      if: ${{ steps.atmos-plan.outputs.error == 'false' && steps.config.outputs.backend == 'google' }}
+      uses: shirkevich/github-action-terraform-plan-storage@google-cloud-backend
+      with:
+        action: storePlan
+        commitSHA: ${{ inputs.sha }}
+        planPath: ${{ steps.vars.outputs.lock_file }}
+        component: ${{ inputs.component }}
+        stack: ${{ inputs.stack }}-lockfile
+        planRepositoryType: gcs
+        gcpCredentials: ${{ inputs.gcp-credentials }}
+        gcpProjectId: ${{ steps.config.outputs.gcp-project-id }}
+        metadataRepositoryType: firestore
 
     - name: Setup Infracost
       if: ${{ steps.config.outputs.enable-infracost == 'true' && steps.atmos-plan.outputs.changes == 'true' }}

--- a/action.yml
+++ b/action.yml
@@ -106,11 +106,11 @@ runs:
       with:
         cache: true
         config: |-
-          opentofu/opentofu: 
+          opentofu/opentofu:
             tag: ${{ startsWith(steps.config.outputs.opentofu-version, 'v') && steps.config.outputs.opentofu-version || format('v{0}', steps.config.outputs.opentofu-version) }}
             skip: ${{ steps.config.outputs.opentofu-version == '' || steps.config.outputs.opentofu-version == 'null' }}
           suzuki-shunsuke/tfcmt:
-            tag: v4.11.0  
+            tag: v4.11.0
 
     - name: Configure Plan AWS Credentials
       if: ${{ steps.config.outputs.backend == 'aws' }}

--- a/action.yml
+++ b/action.yml
@@ -148,14 +148,6 @@ runs:
             outputPath: command
           - component: ${{ inputs.component }}
             stack: ${{ inputs.stack }}
-            settingsPath: settings.integrations.github.gitops.opentofu-version
-            outputPath: opentofu-version
-          - component: ${{ inputs.component }}
-            stack: ${{ inputs.stack }}
-            settingsPath: settings.integrations.github.gitops.terraform-version
-            outputPath: terraform-version
-          - component: ${{ inputs.component }}
-            stack: ${{ inputs.stack }}
             settingsPath: settings.integrations.github.gitops.infracost-enabled
             outputPath: enable-infracost
           - component: ${{ inputs.component }}

--- a/action.yml
+++ b/action.yml
@@ -88,6 +88,13 @@ runs:
         token: ${{ inputs.token }}
         install-wrapper: false
 
+    - name: Install OpenTofu
+      uses: cloudposse-github-actions/install-gh-releases@v1
+      with:
+        cache: true
+        config: |-
+          opentofu/opentofu: latest
+
     - name: Get atmos settings
       id: atmos-settings
       uses: cloudposse/github-action-atmos-get-setting@v2

--- a/action.yml
+++ b/action.yml
@@ -85,6 +85,40 @@ runs:
         token: ${{ inputs.token }}
         install-wrapper: false
 
+    - name: Get terraform and opentofu versions
+      id: terraform-versions
+      uses: cloudposse/github-action-atmos-get-setting@v2
+      with:
+        process-templates: false
+        settings: |
+          - component: ${{ inputs.component }}
+            stack: ${{ inputs.stack }}
+            settingsPath: settings.integrations.github.gitops.opentofu-version
+            outputPath: opentofu-version
+          - component: ${{ inputs.component }}
+            stack: ${{ inputs.stack }}
+            settingsPath: settings.integrations.github.gitops.terraform-version
+            outputPath: terraform-version
+
+    - name: Install Terraform
+      if: ${{ fromJson(steps.terraform-versions.outputs.settings).terraform-version != '' && fromJson(steps.terraform-versions.outputs.settings).terraform-version != 'null' }}
+      uses: hashicorp/setup-terraform@v3
+      with:
+        terraform_version: ${{ fromJson(steps.terraform-versions.outputs.settings).terraform-version }}
+        terraform_wrapper: false
+
+    - name: Install Dependencies
+      uses: cloudposse-github-actions/install-gh-releases@v1
+      with:
+        cache: true
+        config: |-
+          opentofu/opentofu:
+            tag: ${{ startsWith(fromJson(steps.terraform-versions.outputs.settings).opentofu-version, 'v') && fromJson(steps.terraform-versions.outputs.settings).opentofu-version || format('v{0}', fromJson(steps.terraform-versions.outputs.settings).opentofu-version) }}
+            skip: ${{ fromJson(steps.terraform-versions.outputs.settings).opentofu-version == '' || fromJson(steps.terraform-versions.outputs.settings).opentofu-version == 'null' }}
+          suzuki-shunsuke/tfcmt:
+            tag: v4.14.0
+
+
     - name: Get atmos settings
       id: atmos-settings
       uses: cloudposse/github-action-atmos-get-setting@v2
@@ -186,24 +220,6 @@ runs:
             stack: ${{ inputs.stack }}
             settingsPath: settings.integrations.github.gitops.artifact-storage.google-firestore-collection-name
             outputPath: google-firestore-collection-name
-
-    - name: Install Terraform
-      if: ${{ fromJson(steps.atmos-settings.outputs.settings).terraform-version != '' && fromJson(steps.atmos-settings.outputs.settings).terraform-version != 'null' }}
-      uses: hashicorp/setup-terraform@v3
-      with:
-        terraform_version: ${{ fromJson(steps.atmos-settings.outputs.settings).terraform-version }}
-        terraform_wrapper: false
-
-    - name: Install Dependencies
-      uses: cloudposse-github-actions/install-gh-releases@v1
-      with:
-        cache: true
-        config: |-
-          opentofu/opentofu: 
-            tag: ${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).opentofu-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).opentofu-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).opentofu-version) }}
-            skip: ${{ fromJson(steps.atmos-settings.outputs.settings).opentofu-version == '' || fromJson(steps.atmos-settings.outputs.settings).opentofu-version == 'null' }}
-          suzuki-shunsuke/tfcmt:
-            tag: v4.14.0  
 
     - name: Configure Plan AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4

--- a/action.yml
+++ b/action.yml
@@ -51,9 +51,7 @@ inputs:
       not supplied by the user. When running this action on github.com, the default value is sufficient. When running on
       GHES, you can pass a personal access token for github.com if you are experiencing rate limiting.
     default: ${{ github.server_url == 'https://github.com' && github.token || '' }}
-  gcp-credentials:
-    description: "Google Cloud service account key JSON"
-    required: false
+
 outputs:
   summary:
     description: "Summary"
@@ -89,6 +87,8 @@ runs:
         echo "backend=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"].backend')" >> $GITHUB_OUTPUT
         echo "aws-region=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"].region')" >> $GITHUB_OUTPUT
         echo "gcp-project-id=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"]."gcp-project-id"')" >> $GITHUB_OUTPUT
+        echo "google-workload-identity-provider=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"]."google-workload-identity-provider"')" >> $GITHUB_OUTPUT
+        echo "google-service-account=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"]."google-service-account"')" >> $GITHUB_OUTPUT
         echo "terraform-state-role=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"].role')" >> $GITHUB_OUTPUT
         echo "terraform-state-table=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"].table')" >> $GITHUB_OUTPUT
         echo "terraform-state-bucket=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"].bucket')" >> $GITHUB_OUTPUT        
@@ -120,6 +120,13 @@ runs:
         role-to-assume: ${{ steps.config.outputs.terraform-plan-role }}
         role-session-name: "atmos-terraform-plan-gitops"
         mask-aws-account-id: "no"
+
+    - name: Configure Plan Google Credentials
+      if: ${{ fromJson(steps.component.outputs.settings).enabled && inputs.backend == 'google' }}
+      uses: google-github-actions/auth@v2
+      with:
+        workload_identity_provider: ${{ steps.config.outputs.google-workload-identity-provider }}
+        service_account: ${{ steps.config.outputs.google-service-account }}
 
     - name: Get atmos settings
       uses: cloudposse/github-action-atmos-get-setting@v1
@@ -202,12 +209,6 @@ runs:
       run: |
         set +e
         
-        if [[ "${{ steps.config.outputs.backend }}" == "google" ]]; then
-          # Create credentials file and set environment variable
-          echo '${{ inputs.gcp-credentials }}' > /tmp/gcp-credentials.json
-          export GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp-credentials.json
-        fi
-
         TERRAFORM_OUTPUT_FILE="./terraform-${GITHUB_RUN_ID}-output.txt"
 
         tfcmt \

--- a/action.yml
+++ b/action.yml
@@ -300,7 +300,7 @@ runs:
 
     - name: Store New Plan (Google)
       if: ${{ steps.atmos-plan.outputs.error == 'false' && steps.config.outputs.backend == 'google' }}
-      uses: shirkevich/github-action-terraform-plan-storage@3005198d4d647872ca19dcb1734083db9758462a
+      uses: shirkevich/github-action-terraform-plan-storage@d044efc50beac1549e9a088ef7ec63e441ed56f6
       id: store-plan-google
       with:
         action: storePlan
@@ -329,7 +329,7 @@ runs:
 
     - name: Store Lockfile for New Plan (Google)
       if: ${{ steps.atmos-plan.outputs.error == 'false' && steps.config.outputs.backend == 'google' }}
-      uses: shirkevich/github-action-terraform-plan-storage@3005198d4d647872ca19dcb1734083db9758462a
+      uses: shirkevich/github-action-terraform-plan-storage@d044efc50beac1549e9a088ef7ec63e441ed56f6
       with:
         action: storePlan
         commitSHA: ${{ inputs.sha }}

--- a/action.yml
+++ b/action.yml
@@ -300,7 +300,7 @@ runs:
 
     - name: Store New Plan (Google)
       if: ${{ steps.atmos-plan.outputs.error == 'false' && steps.config.outputs.backend == 'google' }}
-      uses: shirkevich/github-action-terraform-plan-storage@google-cloud-backend?v=1
+      uses: shirkevich/github-action-terraform-plan-storage@c6f8f7e
       id: store-plan-google
       with:
         action: storePlan
@@ -328,7 +328,7 @@ runs:
 
     - name: Store Lockfile for New Plan (Google)
       if: ${{ steps.atmos-plan.outputs.error == 'false' && steps.config.outputs.backend == 'google' }}
-      uses: shirkevich/github-action-terraform-plan-storage@google-cloud-backend?v=1
+      uses: shirkevich/github-action-terraform-plan-storage@c6f8f7e
       with:
         action: storePlan
         commitSHA: ${{ inputs.sha }}

--- a/action.yml
+++ b/action.yml
@@ -126,7 +126,7 @@ runs:
         role-session-name: "atmos-terraform-plan-gitops"
         mask-aws-account-id: "no"
 
-    - name: Configure Plan Google Credentials
+    - name: Configure Google Credentials
       if: ${{ steps.config.outputs.backend == 'google' }}
       uses: google-github-actions/auth@v2
       with:
@@ -318,8 +318,10 @@ runs:
         metadataRepositoryType: firestore
         bucketName: ${{ steps.config.outputs.terraform-state-bucket }}
         gcpProjectId: ${{ steps.config.outputs.google-project-id }}
-        gcpFirestoreDatabaseName: ${{ steps.config.outputs.google-firestore-database-name }}
-        gcpFirestoreCollectionName: ${{ steps.config.outputs.google-firestore-collection-name }}
+        ${{ if steps.config.outputs.google-firestore-database-name != 'null' }}:
+          gcpFirestoreDatabaseName: ${{ steps.config.outputs.google-firestore-database-name }}
+        ${{ if steps.config.outputs.google-firestore-collection-name != 'null' }}:
+          gcpFirestoreCollectionName: ${{ steps.config.outputs.google-firestore-collection-name }}
 
     - name: Store Lockfile for New Plan (AWS)
       if: ${{ steps.atmos-plan.outputs.error == 'false' && steps.config.outputs.backend == 'aws' }}

--- a/action.yml
+++ b/action.yml
@@ -300,7 +300,7 @@ runs:
 
     - name: Store New Plan (Google)
       if: ${{ steps.atmos-plan.outputs.error == 'false' && steps.config.outputs.backend == 'google' }}
-      uses: shirkevich/github-action-terraform-plan-storage@c6f8f7e
+      uses: shirkevich/github-action-terraform-plan-storage@c6f8f7e0fdb4f8ed21ebceec068a68117fb9114f
       id: store-plan-google
       with:
         action: storePlan
@@ -328,7 +328,7 @@ runs:
 
     - name: Store Lockfile for New Plan (Google)
       if: ${{ steps.atmos-plan.outputs.error == 'false' && steps.config.outputs.backend == 'google' }}
-      uses: shirkevich/github-action-terraform-plan-storage@c6f8f7e
+      uses: shirkevich/github-action-terraform-plan-storage@c6f8f7e0fdb4f8ed21ebceec068a68117fb9114f
       with:
         action: storePlan
         commitSHA: ${{ inputs.sha }}

--- a/action.yml
+++ b/action.yml
@@ -57,6 +57,9 @@ outputs:
     description: "Summary"
     value: "${{ steps.summary.outputs.result }}"
 
+env:
+  ACTIONS_STEP_DEBUG: true
+
 runs:
   using: "composite"
   steps:

--- a/action.yml
+++ b/action.yml
@@ -89,10 +89,11 @@ runs:
         echo "enable-infracost=$(atmos describe config -f json | jq -r '.integrations.github.gitops["infracost-enabled"]')" >> $GITHUB_OUTPUT        
         echo "backend=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"].backend')" >> $GITHUB_OUTPUT
         echo "aws-region=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"].region')" >> $GITHUB_OUTPUT
-        echo "gcp-project-id=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"]."gcp-project-id"')" >> $GITHUB_OUTPUT
-        echo "google-firestore-database-id=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"]."google-firestore-database-id"')" >> $GITHUB_OUTPUT
+        echo "google-project-id=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"]."google-project-id"')" >> $GITHUB_OUTPUT
         echo "google-workload-identity-provider=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"]."google-workload-identity-provider"')" >> $GITHUB_OUTPUT
         echo "google-service-account=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"]."google-service-account"')" >> $GITHUB_OUTPUT
+        echo "google-firestore-database-name=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"]."google-firestore-database-name"')" >> $GITHUB_OUTPUT
+        echo "google-firestore-collection-name=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"]."google-firestore-collection-name"')" >> $GITHUB_OUTPUT
         echo "terraform-state-role=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"].role')" >> $GITHUB_OUTPUT
         echo "terraform-state-table=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"].table')" >> $GITHUB_OUTPUT
         echo "terraform-state-bucket=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"].bucket')" >> $GITHUB_OUTPUT        
@@ -316,7 +317,7 @@ runs:
         planRepositoryType: gcs
         metadataRepositoryType: firestore
         bucketName: ${{ steps.config.outputs.terraform-state-bucket }}
-        gcpProjectId: ${{ steps.config.outputs.gcp-project-id }}
+        gcpProjectId: ${{ steps.config.outputs.google-project-id }}
         gcpFirestoreDatabaseName: ${{ steps.config.outputs.google-firestore-database-name }}
         gcpFirestoreCollectionName: ${{ steps.config.outputs.google-firestore-collection-name }}
 

--- a/action.yml
+++ b/action.yml
@@ -262,9 +262,13 @@ runs:
       run: |
         STACK_NAME=$(echo "${{ inputs.stack }}" | sed 's#/#_#g')
         COMPONENT_PATH=${{ fromJson(steps.atmos-settings.outputs.settings).component-path }}
+        # Normalize absolute component_path to relative to GITHUB_WORKSPACE so ./$COMPONENT_PATH resolves correctly
+        if [[ "$COMPONENT_PATH" == /* ]]; then
+          COMPONENT_PATH=".${COMPONENT_PATH#$GITHUB_WORKSPACE}"
+        fi
         COMPONENT_NAME=$(echo "${{ inputs.component }}" | sed 's#/#_#g')
         COMPONENT_SLUG="$STACK_NAME-$COMPONENT_NAME"
-        COMPONENT_CACHE_KEY=$(basename "${{ fromJson(steps.atmos-settings.outputs.settings).component-path }}") 
+        COMPONENT_CACHE_KEY=$(basename "$COMPONENT_PATH")
         PLAN_FILE="$( realpath ${COMPONENT_PATH})/$COMPONENT_SLUG-${{ inputs.sha }}.planfile"
         LOCK_FILE="$( realpath ${COMPONENT_PATH})/.terraform.lock.hcl"
 

--- a/action.yml
+++ b/action.yml
@@ -277,7 +277,7 @@ runs:
         rm -f ${TERRAFORM_OUTPUT_FILE}
 
     - name: Configure State AWS Credentials
-      if: ${{ steps.atmos-plan.outputs.error == 'false' }}
+      if: ${{ steps.atmos-plan.outputs.error == 'false' && steps.config.outputs.backend == 'aws' }}
       uses: aws-actions/configure-aws-credentials@v4.0.2
       with:
         aws-region: ${{ steps.config.outputs.aws-region }}

--- a/action.yml
+++ b/action.yml
@@ -122,7 +122,7 @@ runs:
         mask-aws-account-id: "no"
 
     - name: Configure Plan Google Credentials
-      if: ${{ fromJson(steps.component.outputs.settings).enabled && inputs.backend == 'google' }}
+      if: ${{ fromJson(steps.component.outputs.settings).enabled && steps.config.outputs.backend == 'google' }}
       uses: google-github-actions/auth@v2
       with:
         workload_identity_provider: ${{ steps.config.outputs.google-workload-identity-provider }}

--- a/action.yml
+++ b/action.yml
@@ -90,6 +90,7 @@ runs:
         echo "backend=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"].backend')" >> $GITHUB_OUTPUT
         echo "aws-region=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"].region')" >> $GITHUB_OUTPUT
         echo "gcp-project-id=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"]."gcp-project-id"')" >> $GITHUB_OUTPUT
+        echo "google-firestore-database-id=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"]."google-firestore-database-id"')" >> $GITHUB_OUTPUT
         echo "google-workload-identity-provider=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"]."google-workload-identity-provider"')" >> $GITHUB_OUTPUT
         echo "google-service-account=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"]."google-service-account"')" >> $GITHUB_OUTPUT
         echo "terraform-state-role=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"].role')" >> $GITHUB_OUTPUT
@@ -313,11 +314,11 @@ runs:
         component: ${{ inputs.component }}
         stack: ${{ inputs.stack }}
         planRepositoryType: gcs
-        gcpCredentials: ${{ inputs.gcp-credentials }}
         gcpProjectId: ${{ steps.config.outputs.gcp-project-id }}
         metadataRepositoryType: firestore
         tableName: ${{ steps.config.outputs.terraform-state-table }}
         bucketName: ${{ steps.config.outputs.terraform-state-bucket }}
+        databaseId: ${{ steps.config.outputs.google-firestore-database-id }}
 
     - name: Store Lockfile for New Plan (AWS)
       if: ${{ steps.atmos-plan.outputs.error == 'false' && steps.config.outputs.backend == 'aws' }}
@@ -341,12 +342,11 @@ runs:
         component: ${{ inputs.component }}
         stack: ${{ inputs.stack }}-lockfile
         planRepositoryType: gcs
-        gcpCredentials: ${{ inputs.gcp-credentials }}
         gcpProjectId: ${{ steps.config.outputs.gcp-project-id }}
         metadataRepositoryType: firestore
         tableName: ${{ steps.config.outputs.terraform-state-table }}
         bucketName: ${{ steps.config.outputs.terraform-state-bucket }}
-
+        databaseId: ${{ steps.config.outputs.google-firestore-database-id }}
     - name: Setup Infracost
       if: ${{ steps.config.outputs.enable-infracost == 'true' && steps.atmos-plan.outputs.changes == 'true' }}
       uses: infracost/actions/setup@v3

--- a/action.yml
+++ b/action.yml
@@ -318,10 +318,8 @@ runs:
         metadataRepositoryType: firestore
         bucketName: ${{ steps.config.outputs.terraform-state-bucket }}
         gcpProjectId: ${{ steps.config.outputs.google-project-id }}
-        ${{ if steps.config.outputs.google-firestore-database-name != 'null' }}:
-          gcpFirestoreDatabaseName: ${{ steps.config.outputs.google-firestore-database-name }}
-        ${{ if steps.config.outputs.google-firestore-collection-name != 'null' }}:
-          gcpFirestoreCollectionName: ${{ steps.config.outputs.google-firestore-collection-name }}
+        gcpFirestoreDatabaseName: ${{ steps.config.outputs.google-firestore-database-name }}
+        gcpFirestoreCollectionName: ${{ steps.config.outputs.google-firestore-collection-name }}
 
     - name: Store Lockfile for New Plan (AWS)
       if: ${{ steps.atmos-plan.outputs.error == 'false' && steps.config.outputs.backend == 'aws' }}

--- a/action.yml
+++ b/action.yml
@@ -202,6 +202,12 @@ runs:
       run: |
         set +e
         
+        if [[ "${{ steps.config.outputs.backend }}" == "google" ]]; then
+          # Create credentials file and set environment variable
+          echo '${{ inputs.gcp-credentials }}' > /tmp/gcp-credentials.json
+          export GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp-credentials.json
+        fi
+
         TERRAFORM_OUTPUT_FILE="./terraform-${GITHUB_RUN_ID}-output.txt"
 
         tfcmt \

--- a/action.yml
+++ b/action.yml
@@ -313,6 +313,7 @@ runs:
         gcpProjectId: ${{ steps.config.outputs.gcp-project-id }}
         metadataRepositoryType: firestore
         tableName: ${{ steps.config.outputs.terraform-state-table }}
+        bucketName: ${{ steps.config.outputs.terraform-state-bucket }}
 
     - name: Store Lockfile for New Plan (AWS)
       if: ${{ steps.atmos-plan.outputs.error == 'false' && steps.config.outputs.backend == 'aws' }}
@@ -340,6 +341,8 @@ runs:
         gcpProjectId: ${{ steps.config.outputs.gcp-project-id }}
         metadataRepositoryType: firestore
         tableName: ${{ steps.config.outputs.terraform-state-table }}
+        bucketName: ${{ steps.config.outputs.terraform-state-bucket }}
+
     - name: Setup Infracost
       if: ${{ steps.config.outputs.enable-infracost == 'true' && steps.atmos-plan.outputs.changes == 'true' }}
       uses: infracost/actions/setup@v3

--- a/action.yml
+++ b/action.yml
@@ -175,6 +175,14 @@ runs:
             outputPath: google-project-id
           - component: ${{ inputs.component }}
             stack: ${{ inputs.stack }}
+            settingsPath: settings.integrations.github.gitops.artifact-storage.google-service-account
+            outputPath: google-service-account
+          - component: ${{ inputs.component }}
+            stack: ${{ inputs.stack }}
+            settingsPath: settings.integrations.github.gitops.artifact-storage.google-workload-identity-provider
+            outputPath: google-workload-identity-provider
+          - component: ${{ inputs.component }}
+            stack: ${{ inputs.stack }}
             settingsPath: settings.integrations.github.gitops.artifact-storage.google-firestore-database-name
             outputPath: google-firestore-database-name
           - component: ${{ inputs.component }}

--- a/action.yml
+++ b/action.yml
@@ -445,9 +445,9 @@ runs:
         cosmosContainerName: ${{ fromJson(steps.atmos-settings.outputs.settings).cosmos-container-name }}
         cosmosDatabaseName: ${{ fromJson(steps.atmos-settings.outputs.settings).cosmos-database-name }}
         cosmosEndpoint: ${{ fromJson(steps.atmos-settings.outputs.settings).cosmos-endpoint }}
-        gcpProjectId: ${{ steps.config.outputs.google-project-id }}
-        gcpFirestoreDatabaseName: ${{ steps.config.outputs.google-firestore-database-name }}
-        gcpFirestoreCollectionName: ${{ steps.config.outputs.google-firestore-collection-name }}
+        gcpProjectId: ${{ fromJson(steps.atmos-settings.outputs.settings).google-project-id }}
+        gcpFirestoreDatabaseName: ${{ fromJson(steps.atmos-settings.outputs.settings).google-firestore-database-name }}
+        gcpFirestoreCollectionName: ${{ fromJson(steps.atmos-settings.outputs.settings).google-firestore-collection-name }}
         tableName: ${{ fromJson(steps.atmos-settings.outputs.settings).terraform-state-table }}
         bucketName: ${{ fromJson(steps.atmos-settings.outputs.settings).terraform-state-bucket }}
 

--- a/action.yml
+++ b/action.yml
@@ -125,7 +125,7 @@ runs:
         mask-aws-account-id: "no"
 
     - name: Configure Plan Google Credentials
-      if: ${{ fromJson(steps.component.outputs.settings).enabled && steps.config.outputs.backend == 'google' }}
+      if: ${{ steps.config.outputs.backend == 'google' }}
       uses: google-github-actions/auth@v2
       with:
         workload_identity_provider: ${{ steps.config.outputs.google-workload-identity-provider }}

--- a/action.yml
+++ b/action.yml
@@ -300,7 +300,7 @@ runs:
 
     - name: Store New Plan (Google)
       if: ${{ steps.atmos-plan.outputs.error == 'false' && steps.config.outputs.backend == 'google' }}
-      uses: shirkevich/github-action-terraform-plan-storage@935c724bfe991c8b12260981f37118063cd5f400
+      uses: shirkevich/github-action-terraform-plan-storage@8cc27bfcbf945d0e54ae90b9357462ac528f781a
       id: store-plan-google
       with:
         action: storePlan
@@ -328,7 +328,7 @@ runs:
 
     - name: Store Lockfile for New Plan (Google)
       if: ${{ steps.atmos-plan.outputs.error == 'false' && steps.config.outputs.backend == 'google' }}
-      uses: shirkevich/github-action-terraform-plan-storage@935c724bfe991c8b12260981f37118063cd5f400
+      uses: shirkevich/github-action-terraform-plan-storage@8cc27bfcbf945d0e54ae90b9357462ac528f781a
       with:
         action: storePlan
         commitSHA: ${{ inputs.sha }}

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -16,6 +16,7 @@
 | sha | Commit SHA to plan. Default: github.sha | ${{ github.event.pull\_request.head.sha }} | true |
 | stack | The stack name for the given component. | N/A | true |
 | token | Used to pull node distributions for Atmos from Cloud Posse's GitHub repository. Since there's a default, this is typically not supplied by the user. When running this action on github.com, the default value is sufficient. When running on GHES, you can pass a personal access token for github.com if you are experiencing rate limiting. | ${{ github.server\_url == 'https://github.com' && github.token \|\| '' }} | false |
+| gcp-credentials | Google Cloud service account key JSON | N/A | false |
 
 
 ## Outputs

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -16,7 +16,6 @@
 | sha | Commit SHA to plan. Default: github.sha | ${{ github.event.pull\_request.head.sha }} | true |
 | stack | The stack name for the given component. | N/A | true |
 | token | Used to pull node distributions for Atmos from Cloud Posse's GitHub repository. Since there's a default, this is typically not supplied by the user. When running this action on github.com, the default value is sufficient. When running on GHES, you can pass a personal access token for github.com if you are experiencing rate limiting. | ${{ github.server\_url == 'https://github.com' && github.token \|\| '' }} | false |
-| gcp-credentials | Google Cloud service account key JSON | N/A | false |
 
 
 ## Outputs


### PR DESCRIPTION
## what

Use google services to retrieve the state (gcs) and metadata (firestore)

## why

For those who use google cloud it is hard to adopt atmos as all the GH tooling is built around AWS. This PR and several other fixes that.

## references

See also related PRs in:

* https://github.com/cloudposse/github-action-terraform-plan-storage/pull/35
* https://github.com/cloudposse/github-action-atmos-terraform-apply/pull/64
* https://github.com/cloudposse/github-action-atmos-affected-stacks/pull/55

## need help

To proper name the fields in metadata for google cloud. 