### PR TITLE
Use Aqua to Install Deps

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -58,3 +58,4 @@ jobs:
           atmos-config-path: ${{ runner.temp }}
           atmos-version: 1.99.0
           skip-checkout: true
+          debug: true

--- a/action.yml
+++ b/action.yml
@@ -320,7 +320,7 @@ runs:
         -var "logoUrl:${{ inputs.branding-logo-url }}" \
         -var "infracost_enabled:${{ fromJson(steps.atmos-settings.outputs.settings).enable-infracost }}" \
         -var "driftModeEnabled:${{ inputs.drift-detection-mode-enabled }}" \
-        --output ${{ steps.vars.outputs.summary_file }}" \
+        --output "${{ steps.vars.outputs.summary_file }}" \
         --log-level $([[ "${{ inputs.debug }}" == "true" ]] && echo "DEBUG" || echo "INFO") \
         plan \
         $([[ "${{ inputs.pr-comment }}" == "true" ]] && echo "-patch") \

--- a/action.yml
+++ b/action.yml
@@ -320,7 +320,7 @@ runs:
         -var "logoUrl:${{ inputs.branding-logo-url }}" \
         -var "infracost_enabled:${{ fromJson(steps.atmos-settings.outputs.settings).enable-infracost }}" \
         -var "driftModeEnabled:${{ inputs.drift-detection-mode-enabled }}" \
-        $([[ "${{ inputs.pr-comment }}" == "false" ]] && echo "--output ${{ steps.vars.outputs.summary_file }}") \
+        --output ${{ steps.vars.outputs.summary_file }}" \
         --log-level $([[ "${{ inputs.debug }}" == "true" ]] && echo "DEBUG" || echo "INFO") \
         plan \
         $([[ "${{ inputs.pr-comment }}" == "true" ]] && echo "-patch") \
@@ -334,6 +334,12 @@ runs:
         &> ${TERRAFORM_OUTPUT_FILE}
 
         TERRAFORM_RESULT=$?
+    
+        if [[ "${{ inputs.debug }}" == "true" ]]; then
+          echo "tfcmt exit code: $?"
+          ls -l "${{ steps.vars.outputs.summary_file }}" || echo "summary file not found"
+          cat ${TERRAFORM_OUTPUT_FILE}
+        fi
 
         if [[ "${{ inputs.pr-comment }}" == "true" ]]; then
           tfcmt \

--- a/action.yml
+++ b/action.yml
@@ -176,23 +176,33 @@ runs:
             settingsPath: settings.integrations.github.gitops.artifact-storage.cosmos-endpoint
             outputPath: cosmos-endpoint
 
-    - name: Install dependencies
+    - name: Install dependencies (Terraform)
       uses: aquaproj/aqua-installer@5e54e5cee8a95ee2ce7c04cb993da6dfad13e59c # v3.1.2
       with:
         aqua_version: v2.50.0
+        aqua_opts: "hashicorp/terraform@1.5.2"
       env:
         AQUA_CONFIG: aqua.yaml
         AQUA_LOG_LEVEL: debug
 
-    - name: Install Dependencies
-      uses: cloudposse-github-actions/install-gh-releases@v1
+    - name: Install dependencies (OpenTofu)
+      uses: aquaproj/aqua-installer@5e54e5cee8a95ee2ce7c04cb993da6dfad13e59c # v3.1.2
       with:
-        cache: true
-        config: |-
-          opentofu/opentofu:
-            tag: ${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).opentofu-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).opentofu-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).opentofu-version) }}
-            skip: ${{ fromJson(steps.atmos-settings.outputs.settings).opentofu-version == '' || fromJson(steps.atmos-settings.outputs.settings).opentofu-version == 'null' }}
-          suzuki-shunsuke/tfcmt: v4.14.0
+        aqua_version: v2.50.0
+        aqua_opts: "opentofu/opentofu@v1.9.1"
+      env:
+        AQUA_CONFIG: aqua.yaml
+        AQUA_LOG_LEVEL: debug
+
+        #- name: Install Dependencies
+        #  uses: cloudposse-github-actions/install-gh-releases@v1
+        #  with:
+        #    cache: true
+        #    config: |-
+        #      opentofu/opentofu:
+        #        tag: ${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).opentofu-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).opentofu-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).opentofu-version) }}
+        #        skip: ${{ fromJson(steps.atmos-settings.outputs.settings).opentofu-version == '' || fromJson(steps.atmos-settings.outputs.settings).opentofu-version == 'null' }}
+        #      suzuki-shunsuke/tfcmt: v4.14.0
 
     - name: Configure Plan AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4

--- a/action.yml
+++ b/action.yml
@@ -176,9 +176,9 @@ runs:
             settingsPath: settings.integrations.github.gitops.artifact-storage.cosmos-endpoint
             outputPath: cosmos-endpoint
 
-          #hashicorp/terraform:
-          #  tag: ${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).terraform-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).terraform-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).terraform-version) }}
-          #  skip: ${{ fromJson(steps.atmos-settings.outputs.settings).terraform-version == '' || fromJson(steps.atmos-settings.outputs.settings).terraform-version == 'null' }}
+    #hashicorp/terraform:
+    #  tag: ${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).terraform-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).terraform-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).terraform-version) }}
+    #  skip: ${{ fromJson(steps.atmos-settings.outputs.settings).terraform-version == '' || fromJson(steps.atmos-settings.outputs.settings).terraform-version == 'null' }}
     - name: Install Dependencies
       uses: cloudposse-github-actions/install-gh-releases@v1
       with:

--- a/action.yml
+++ b/action.yml
@@ -263,8 +263,6 @@ runs:
         COMPONENT_PATH=${{ fromJson(steps.atmos-settings.outputs.settings).component-path }}
         COMPONENT_NAME=$(echo "${{ inputs.component }}" | sed 's#/#_#g')
         COMPONENT_SLUG="$STACK_NAME-$COMPONENT_NAME"
-        # We need separate caches for Terraform and OpenTofu!
-        # Append the command to the key to ensure different caches for each command.
         COMPONENT_CACHE_KEY="${{ fromJson(steps.atmos-settings.outputs.settings).components.terraform.command || 'terraform' }}-$(basename ${{ fromJson(steps.atmos-settings.outputs.settings).component-path }})"
         PLAN_FILE="$( realpath ${COMPONENT_PATH})/$COMPONENT_SLUG-${{ inputs.sha }}.planfile"
         PLAN_FILE_JSON="$( realpath ${COMPONENT_PATH})/$COMPONENT_SLUG-${{ inputs.sha }}.planfile.json"
@@ -362,13 +360,21 @@ runs:
         set -e
 
         if [[ "${{ inputs.drift-detection-mode-enabled }}" == "true" ]]; then
-          # Split summary to 2 files - issue and step summary files
-          # Remove \0 at the end of the grep output
+          # In drift detection mode, split the summary into two parts:
+          # 1. Step summary (before the marker) - shown in GitHub Actions UI
+          # 2. Issue description (after the marker) - used to create GitHub issues
           grep -Pzo '(.|\n)*(?=_______________ISSUE-MARKDOWN_______________\n)' ${{ steps.vars.outputs.summary_file }} | grep -Pav  "\x00" > ${{ steps.vars.outputs.step_summary_file }}
           grep -Pzo '(?<=_______________ISSUE-MARKDOWN_______________\n)(.|\n)*' ${{ steps.vars.outputs.summary_file }} | grep -Pav  "\x00" > ${{ steps.vars.outputs.issue_file }}
+          # Clean up original file since content is now split
           rm -f ${{ steps.vars.outputs.summary_file }}
         else
-          mv ${{ steps.vars.outputs.summary_file }} ${{ steps.vars.outputs.step_summary_file }}
+          # In normal mode, safely move the summary to step summary location if it exists
+          if [ -f "${{ steps.vars.outputs.summary_file }}" ]; then
+            mv "${{ steps.vars.outputs.summary_file }}" "${{ steps.vars.outputs.step_summary_file }}"
+          else
+            # If summary file doesn't exist (e.g., when pr-comment is true), create an empty step summary
+            touch "${{ steps.vars.outputs.step_summary_file }}"
+          fi
         fi
 
         cat "${TERRAFORM_OUTPUT_FILE}"

--- a/action.yml
+++ b/action.yml
@@ -181,15 +181,13 @@ runs:
       with:
         cache: true
         config: |-
-
+          suzuki-shunsuke/tfcmt: v4.14.0
           hashicorp/terraform:
             tag: ${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).terraform-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).terraform-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).terraform-version) }}
             skip: ${{ fromJson(steps.atmos-settings.outputs.settings).terraform-version == '' || fromJson(steps.atmos-settings.outputs.settings).terraform-version == 'null' }}
           opentofu/opentofu:
             tag: ${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).opentofu-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).opentofu-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).opentofu-version) }}
             skip: ${{ fromJson(steps.atmos-settings.outputs.settings).opentofu-version == '' || fromJson(steps.atmos-settings.outputs.settings).opentofu-version == 'null' }}
-          suzuki-shunsuke/tfcmt:
-            tag: v4.14.0
 
     - name: Configure Plan AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4

--- a/action.yml
+++ b/action.yml
@@ -176,32 +176,39 @@ runs:
             settingsPath: settings.integrations.github.gitops.artifact-storage.cosmos-endpoint
             outputPath: cosmos-endpoint
 
+    - name: Install Terraform
+      if: ${{ fromJson(steps.atmos-settings.outputs.settings).terraform-version != '' && fromJson(steps.atmos-settings.outputs.settings).terraform-version != 'null' }}
+      run: |
+        set -eux
+
+        # Pin your version here
+        TERRAFORM_VERSION="${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).terraform-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).terraform-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).terraform-version) }}"
+
+        # Map runner.os → lowercase (linux, darwin, windows)
+        OS="${{ runner.os | toLowerCase() }}"
+
+        # Map runner.architecture → terraform’s naming
+        case "${{ runner.architecture }}" in
+          X64)   ARCH="amd64" ;;
+          ARM64) ARCH="arm64" ;;
+          *)     echo "Unsupported ARCH" >&2; exit 1 ;;
+        esac
+
+        URL="https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_${OS}_${ARCH}.zip"
+
+        curl -fsSL "$URL" -o terraform.zip
+        unzip terraform.zip
+        sudo mv terraform /usr/local/bin/
+
     - name: Install Dependencies
       uses: cloudposse-github-actions/install-gh-releases@v1
       with:
         cache: true
-        config: >-
-          {
-            "hashicorp/terraform": {
-              "tag": "v1.5.2",
-              "extension-matching": true
-            },
-            "opentofu/opentofu": {
-              "skip": true
-            },
-            "suzuki-shunsuke/tfcmt": {
-              "tag": "v4.14.0"
-            }
-          }
-        #config: |-
-        #    hashicorp/terraform:
-        #      tag: ${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).terraform-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).terraform-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).terraform-version) }}
-        #      skip: ${{ fromJson(steps.atmos-settings.outputs.settings).terraform-version == '' || fromJson(steps.atmos-settings.outputs.settings).terraform-version == 'null' }}
-        #      extension-matching: true
-        #    opentofu/opentofu:
-        #      tag: ${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).opentofu-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).opentofu-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).opentofu-version) }}
-        #      skip: ${{ fromJson(steps.atmos-settings.outputs.settings).opentofu-version == '' || fromJson(steps.atmos-settings.outputs.settings).opentofu-version == 'null' }}
-        #    suzuki-shunsuke/tfcmt: v4.14.0
+        config: |-
+          opentofu/opentofu:
+            tag: ${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).opentofu-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).opentofu-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).opentofu-version) }}
+            skip: ${{ fromJson(steps.atmos-settings.outputs.settings).opentofu-version == '' || fromJson(steps.atmos-settings.outputs.settings).opentofu-version == 'null' }}
+          suzuki-shunsuke/tfcmt: v4.14.0
 
     - name: Configure Plan AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4

--- a/action.yml
+++ b/action.yml
@@ -203,6 +203,14 @@ runs:
           cat aqua.yaml
         fi
 
+    - name: Cache Aqua
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      with:
+        path: ~/.local/share/aquaproj-aqua
+        key: v2-aqua-installer-${{runner.os}}-${{runner.arch}}-${{hashFiles('aqua.yaml')}}
+        restore-keys: |
+          v2-aqua-installer-${{runner.os}}-${{runner.arch}}-
+
     - name: Install dependencies with Aqua
       uses: aquaproj/aqua-installer@5e54e5cee8a95ee2ce7c04cb993da6dfad13e59c # v3.1.2
       with:

--- a/action.yml
+++ b/action.yml
@@ -186,7 +186,7 @@ runs:
         TERRAFORM_VERSION="${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).terraform-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).terraform-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).terraform-version) }}"
 
         # Map runner.os → lowercase (linux, darwin, windows)
-        OS="${{ toLower(runner.os) }}"
+        OS="$(echo "${{ runner.os }}" | tr '[:upper:]' '[:lower:]')"
 
         # Map runner.architecture → terraform's naming
         case "${{ runner.architecture }}" in

--- a/action.yml
+++ b/action.yml
@@ -179,8 +179,7 @@ runs:
     - name: Add Terraform and OpenTofu to Aqua
       shell: bash
       run: |
-        # Create aqua config with shared packages
-        cat << EOF > /tmp/aqua.yaml
+        cat << EOF > aqua.yaml
         registries:
           - type: standard
             ref: v4.233.0
@@ -194,7 +193,7 @@ runs:
           if [[ ! "$VERSION" =~ ^v ]]; then
             VERSION="v$VERSION"
           fi
-          echo "  - name: hashicorp/terraform@$VERSION" >> /tmp/aqua.yaml
+          echo "  - name: hashicorp/terraform@$VERSION" >> aqua.yaml
         fi
 
         # Add OpenTofu if specified
@@ -203,13 +202,13 @@ runs:
           if [[ ! "$VERSION" =~ ^v ]]; then
             VERSION="v$VERSION"
           fi
-          echo "  - name: opentofu/opentofu@$VERSION" >> /tmp/aqua.yaml
+          echo "  - name: opentofu/opentofu@$VERSION" >> aqua.yaml
         fi
 
         # Debug output if debug is enabled
         if [[ "${{ inputs.debug }}" == "true" ]]; then
           echo "Generated aqua.yaml:"
-          cat /tmp/aqua.yaml
+          cat aqua.yaml
         fi
 
     - name: Cache Aqua
@@ -224,10 +223,8 @@ runs:
       uses: aquaproj/aqua-installer@5e54e5cee8a95ee2ce7c04cb993da6dfad13e59c # v3.1.2
       with:
         aqua_version: v2.50.0
-        # Disable "-l", the default option: https://aquaproj.github.io/docs/tutorial/install-only-link
-        aqua_opts: ""
       env:
-        AQUA_CONFIG: /tmp/aqua.yaml
+        AQUA_CONFIG: aqua.yaml
         AQUA_LOG_LEVEL: debug
 
     - name: Configure Plan AWS Credentials
@@ -289,7 +286,7 @@ runs:
 
     - name: Cache .terraform
       id: cache
-      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      uses: actions/cache@v4
       if: ${{ fromJson(steps.atmos-settings.outputs.settings).enabled }}
       with:
         path: |
@@ -301,14 +298,6 @@ runs:
       id: atmos-plan
       shell: bash
       run: |
-        # Remove the environment file from the cache to avoid conflicts with workspace select
-        rm -f ./${{ steps.vars.outputs.component_path }}/.terraform/environment
-
-        TERRAFORM_OUTPUT_FILE="./terraform-${GITHUB_RUN_ID}-output.txt"
-
-        # Create the directory for the summary file if it doesn't exist
-        mkdir -p "$(dirname "${{ steps.vars.outputs.summary_file }}")"
-
         # Verify tfcmt is installed
         # Since we disable exit on error, the real error will be swallowed later on
         echo "Ensure tfcmt is installed:"
@@ -318,7 +307,11 @@ runs:
         # and handle it appropriately later in the script
         set +e
 
-        # Run tfcmt, atmos, and terraform to create the plan file
+        # Remove the environment file from the cache to avoid conflicts with workspace select
+        rm -f ./${{ steps.vars.outputs.component_path }}/.terraform/environment
+
+        TERRAFORM_OUTPUT_FILE="./terraform-${GITHUB_RUN_ID}-output.txt"
+
         tfcmt \
         --config ${GITHUB_ACTION_PATH}/config/summary.yaml \
         -owner "${{ github.repository_owner }}" \
@@ -333,7 +326,7 @@ runs:
         -var "logoUrl:${{ inputs.branding-logo-url }}" \
         -var "infracost_enabled:${{ fromJson(steps.atmos-settings.outputs.settings).enable-infracost }}" \
         -var "driftModeEnabled:${{ inputs.drift-detection-mode-enabled }}" \
-        --output "${{ steps.vars.outputs.summary_file }}" \
+        $([[ "${{ inputs.pr-comment }}" == "false" ]] && echo "--output ${{ steps.vars.outputs.summary_file }}") \
         --log-level $([[ "${{ inputs.debug }}" == "true" ]] && echo "DEBUG" || echo "INFO") \
         plan \
         $([[ "${{ inputs.pr-comment }}" == "true" ]] && echo "-patch") \
@@ -347,11 +340,7 @@ runs:
         &> ${TERRAFORM_OUTPUT_FILE}
 
         TERRAFORM_RESULT=$?
-    
-        # Re-enable exit on error
-        set -e
 
-        # If we have comments enabled, we need to run tfcmt again to create a different summary file
         if [[ "${{ inputs.pr-comment }}" == "true" ]]; then
           tfcmt \
           --config ${GITHUB_ACTION_PATH}/config/summary.yaml \
@@ -374,8 +363,8 @@ runs:
             bash -c "cat ${TERRAFORM_OUTPUT_FILE}"
         fi
 
-        # If we have drift detection enabled, we need to split the summary file into 2 files
-        # If we dont, we just move the summary file to the step summary file
+        set -e
+
         if [[ "${{ inputs.drift-detection-mode-enabled }}" == "true" ]]; then
           # Split summary to 2 files - issue and step summary files
           # Remove \0 at the end of the grep output

--- a/action.yml
+++ b/action.yml
@@ -224,6 +224,9 @@ runs:
       uses: aquaproj/aqua-installer@5e54e5cee8a95ee2ce7c04cb993da6dfad13e59c # v3.1.2
       with:
         aqua_version: v2.50.0
+        # Disable "-l", the default option
+        # https://aquaproj.github.io/docs/tutorial/install-only-link
+        aqua_args: ""
       env:
         AQUA_CONFIG: /tmp/aqua.yaml
         AQUA_LOG_LEVEL: debug
@@ -307,11 +310,10 @@ runs:
         # Create the directory for the summary file if it doesn't exist
         mkdir -p "$(dirname "${{ steps.vars.outputs.summary_file }}")"
 
-        # Debug tfcmt
-        if [[ "${{ inputs.debug }}" == "true" ]]; then
-          echo "Debug tfcmt"
-          tfcmt --version
-        fi
+        # Verify tfcmt is installed
+        # Since we disable exit on error, the real error will be swallowed later on
+        echo "Ensure tfcmt is installed:"
+        tfcmt --version
 
         # Disable exit on error so we can capture the terraform exit code
         # and handle it appropriately later in the script

--- a/action.yml
+++ b/action.yml
@@ -181,9 +181,8 @@ runs:
       if: ${{ fromJson(steps.atmos-settings.outputs.settings).terraform-version != '' && fromJson(steps.atmos-settings.outputs.settings).terraform-version != 'null' }}
       with:
         aqua_version: v2.50.0
-        aqua_opts: "aquaproj/registry-standard/hashicorp/terraform@${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).terraform-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).terraform-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).terraform-version) }}"
+        aqua_opts: "-l aquaproj/registry-standard/hashicorp/terraform@${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).terraform-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).terraform-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).terraform-version) }}"
       env:
-        #AQUA_CONFIG: aqua.yaml
         AQUA_LOG_LEVEL: debug
 
     - name: Install dependencies (OpenTofu)
@@ -191,9 +190,8 @@ runs:
       if: ${{ fromJson(steps.atmos-settings.outputs.settings).opentofu-version != '' && fromJson(steps.atmos-settings.outputs.settings).opentofu-version != 'null' }}
       with:
         aqua_version: v2.50.0
-        aqua_opts: "aquaproj/registry-standard/opentofu/opentofu@${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).opentofu-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).opentofu-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).opentofu-version) }}"
+        aqua_opts: "-l aquaproj/registry-standard/opentofu/opentofu@${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).opentofu-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).opentofu-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).opentofu-version) }}"
       env:
-        #AQUA_CONFIG: aqua.yaml
         AQUA_LOG_LEVEL: debug
 
     - name: Install shared dependencies
@@ -202,8 +200,8 @@ runs:
       with:
         aqua_version: v2.50.0
         skip_install_aqua: true
+        aqua_opts: "-l suzuki-shunsuke/tfcmt@v4.14.5"
       env:
-        AQUA_CONFIG: aqua.yaml
         AQUA_LOG_LEVEL: debug
 
     - name: Configure Plan AWS Credentials

--- a/action.yml
+++ b/action.yml
@@ -180,14 +180,19 @@ runs:
       uses: cloudposse-github-actions/install-gh-releases@v1
       with:
         cache: true
-        config: |-
-          hashicorp/terraform:
-            tag: v1.5.2
-            extension-matching: true
-          opentofu/opentofu:
-            skip: true
-          suzuki-shunsuke/tfcmt:
-            tag: v4.14.0
+        config: >-
+          {
+            "hashicorp/terraform": {
+              "tag": "v1.5.2",
+              "extension-matching": true
+            },
+            "opentofu/opentofu": {
+              "skip": true
+            },
+            "suzuki-shunsuke/tfcmt": {
+              "tag": "v4.14.0"
+            }
+          }
         #config: |-
         #    hashicorp/terraform:
         #      tag: ${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).terraform-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).terraform-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).terraform-version) }}

--- a/action.yml
+++ b/action.yml
@@ -186,9 +186,9 @@ runs:
         TERRAFORM_VERSION="${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).terraform-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).terraform-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).terraform-version) }}"
 
         # Map runner.os → lowercase (linux, darwin, windows)
-        OS="${{ runner.os | toLowerCase() }}"
+        OS="${{ toLower(runner.os) }}"
 
-        # Map runner.architecture → terraform’s naming
+        # Map runner.architecture → terraform's naming
         case "${{ runner.architecture }}" in
           X64)   ARCH="amd64" ;;
           ARM64) ARCH="arm64" ;;

--- a/action.yml
+++ b/action.yml
@@ -178,6 +178,7 @@ runs:
 
     - name: Install Terraform
       if: ${{ fromJson(steps.atmos-settings.outputs.settings).terraform-version != '' && fromJson(steps.atmos-settings.outputs.settings).terraform-version != 'null' }}
+      shell: bash
       run: |
         set -eux
 

--- a/action.yml
+++ b/action.yml
@@ -181,14 +181,22 @@ runs:
       with:
         cache: true
         config: |-
-            hashicorp/terraform:
-              tag: ${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).terraform-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).terraform-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).terraform-version) }}
-              skip: ${{ fromJson(steps.atmos-settings.outputs.settings).terraform-version == '' || fromJson(steps.atmos-settings.outputs.settings).terraform-version == 'null' }}
-              extension-matching: true
-            opentofu/opentofu:
-              tag: ${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).opentofu-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).opentofu-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).opentofu-version) }}
-              skip: ${{ fromJson(steps.atmos-settings.outputs.settings).opentofu-version == '' || fromJson(steps.atmos-settings.outputs.settings).opentofu-version == 'null' }}
-            suzuki-shunsuke/tfcmt: v4.14.0
+          hashicorp/terraform:
+            tag: v1.5.2
+            extension-matching: true
+          opentofu/opentofu:
+            skip: true
+          suzuki-shunsuke/tfcmt:
+            tag: v4.14.0
+        #config: |-
+        #    hashicorp/terraform:
+        #      tag: ${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).terraform-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).terraform-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).terraform-version) }}
+        #      skip: ${{ fromJson(steps.atmos-settings.outputs.settings).terraform-version == '' || fromJson(steps.atmos-settings.outputs.settings).terraform-version == 'null' }}
+        #      extension-matching: true
+        #    opentofu/opentofu:
+        #      tag: ${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).opentofu-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).opentofu-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).opentofu-version) }}
+        #      skip: ${{ fromJson(steps.atmos-settings.outputs.settings).opentofu-version == '' || fromJson(steps.atmos-settings.outputs.settings).opentofu-version == 'null' }}
+        #    suzuki-shunsuke/tfcmt: v4.14.0
 
     - name: Configure Plan AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4

--- a/action.yml
+++ b/action.yml
@@ -360,16 +360,13 @@ runs:
         set -e
 
         if [[ "${{ inputs.drift-detection-mode-enabled }}" == "true" ]]; then
-          # In drift detection mode, split the summary into two parts:
-          # 1. Step summary (before the marker) - shown in GitHub Actions UI
-          # 2. Issue description (after the marker) - used to create GitHub issues
+          # Split summary to 2 files - issue and step summary files
+          # Remove \0 at the end of the grep output
           grep -Pzo '(.|\n)*(?=_______________ISSUE-MARKDOWN_______________\n)' ${{ steps.vars.outputs.summary_file }} | grep -Pav  "\x00" > ${{ steps.vars.outputs.step_summary_file }}
           grep -Pzo '(?<=_______________ISSUE-MARKDOWN_______________\n)(.|\n)*' ${{ steps.vars.outputs.summary_file }} | grep -Pav  "\x00" > ${{ steps.vars.outputs.issue_file }}
-          # Clean up original file since content is now split
           rm -f ${{ steps.vars.outputs.summary_file }}
-        elif [ -f "${{ steps.vars.outputs.summary_file }}" ]; then
-          # In normal mode, safely move the summary to step summary location if it exists
-          mv "${{ steps.vars.outputs.summary_file }}" "${{ steps.vars.outputs.step_summary_file }}"
+        elif [[ "${{ inputs.pr-comment }}" == "true" ]]; then
+          mv ${{ steps.vars.outputs.summary_file }} ${{ steps.vars.outputs.step_summary_file }}
         fi
 
         cat "${TERRAFORM_OUTPUT_FILE}"

--- a/action.yml
+++ b/action.yml
@@ -179,11 +179,9 @@ runs:
     - name: Install Dependencies
       uses: cloudposse-github-actions/install-gh-releases@v1
       with:
-        # TODO revert
-        # testing cache disabled
-        #cache: true
-        cache: false
+        cache: true
         config: |-
+
           hashicorp/terraform:
             tag: ${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).terraform-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).terraform-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).terraform-version) }}
             skip: ${{ fromJson(steps.atmos-settings.outputs.settings).terraform-version == '' || fromJson(steps.atmos-settings.outputs.settings).terraform-version == 'null' }}

--- a/action.yml
+++ b/action.yml
@@ -263,7 +263,9 @@ runs:
         COMPONENT_PATH=${{ fromJson(steps.atmos-settings.outputs.settings).component-path }}
         COMPONENT_NAME=$(echo "${{ inputs.component }}" | sed 's#/#_#g')
         COMPONENT_SLUG="$STACK_NAME-$COMPONENT_NAME"
-        COMPONENT_CACHE_KEY=$(basename "${{ fromJson(steps.atmos-settings.outputs.settings).component-path }}")
+        # We need separate caches for Terraform and OpenTofu!
+        # Append the command to the key to ensure different caches for each command.
+        COMPONENT_CACHE_KEY: "${{ fromJson(steps.atmos-settings.outputs.settings).components.terraform.command || 'terraform' }}-$(basename "${{ fromJson(steps.atmos-settings.outputs.settings).component-path }}")"
         PLAN_FILE="$( realpath ${COMPONENT_PATH})/$COMPONENT_SLUG-${{ inputs.sha }}.planfile"
         PLAN_FILE_JSON="$( realpath ${COMPONENT_PATH})/$COMPONENT_SLUG-${{ inputs.sha }}.planfile.json"
         LOCK_FILE="$( realpath ${COMPONENT_PATH})/.terraform.lock.hcl"
@@ -292,9 +294,7 @@ runs:
       with:
         path: |
           ./${{ steps.vars.outputs.component_path }}/.terraform
-        # We need separate caches for Terraform and OpenTofu!
-        # Append the command to the key to ensure different caches for each command.
-        key: ${{ fromJson(steps.atmos-settings.outputs.settings).components.terraform.command || 'terraform' }}-${{ steps.vars.outputs.cache-key }}
+        key: ${{ steps.vars.outputs.cache-key }}
 
     - name: Atmos Terraform Plan
       if: ${{ fromJson(steps.atmos-settings.outputs.settings).enabled }}

--- a/action.yml
+++ b/action.yml
@@ -181,13 +181,16 @@ runs:
       with:
         cache: true
         config: |-
+          # Install or skip Terraform
           hashicorp/terraform:
             tag: ${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).terraform-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).terraform-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).terraform-version) }}
             skip: ${{ fromJson(steps.atmos-settings.outputs.settings).terraform-version == '' || fromJson(steps.atmos-settings.outputs.settings).terraform-version == 'null' }}
             extension-matching: true
+          # Install or skip OpenTofu
           opentofu/opentofu:
             tag: ${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).opentofu-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).opentofu-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).opentofu-version) }}
             skip: ${{ fromJson(steps.atmos-settings.outputs.settings).opentofu-version == '' || fromJson(steps.atmos-settings.outputs.settings).opentofu-version == 'null' }}
+          # Always install tfcmt
           suzuki-shunsuke/tfcmt: v4.14.0
 
     - name: Configure Plan AWS Credentials

--- a/action.yml
+++ b/action.yml
@@ -179,7 +179,8 @@ runs:
     - name: Add Terraform and OpenTofu to Aqua
       shell: bash
       run: |
-        cat << EOF > aqua.yaml
+        # Create aqua config with shared packages
+        cat << EOF > /tmp/aqua.yaml
         registries:
           - type: standard
             ref: v4.233.0
@@ -193,7 +194,7 @@ runs:
           if [[ ! "$VERSION" =~ ^v ]]; then
             VERSION="v$VERSION"
           fi
-          echo "  - name: hashicorp/terraform@$VERSION" >> aqua.yaml
+          echo "  - name: hashicorp/terraform@$VERSION" >> /tmp/aqua.yaml
         fi
 
         # Add OpenTofu if specified
@@ -202,13 +203,13 @@ runs:
           if [[ ! "$VERSION" =~ ^v ]]; then
             VERSION="v$VERSION"
           fi
-          echo "  - name: opentofu/opentofu@$VERSION" >> aqua.yaml
+          echo "  - name: opentofu/opentofu@$VERSION" >> /tmp/aqua.yaml
         fi
 
         # Debug output if debug is enabled
         if [[ "${{ inputs.debug }}" == "true" ]]; then
           echo "Generated aqua.yaml:"
-          cat aqua.yaml
+          cat /tmp/aqua.yaml
         fi
 
     - name: Cache Aqua
@@ -224,7 +225,7 @@ runs:
       with:
         aqua_version: v2.50.0
       env:
-        AQUA_CONFIG: aqua.yaml
+        AQUA_CONFIG: /tmp/aqua.yaml
         AQUA_LOG_LEVEL: debug
 
     - name: Configure Plan AWS Credentials
@@ -262,7 +263,7 @@ runs:
         COMPONENT_PATH=${{ fromJson(steps.atmos-settings.outputs.settings).component-path }}
         COMPONENT_NAME=$(echo "${{ inputs.component }}" | sed 's#/#_#g')
         COMPONENT_SLUG="$STACK_NAME-$COMPONENT_NAME"
-        COMPONENT_CACHE_KEY=$(basename "${{ fromJson(steps.atmos-settings.outputs.settings).component-path }}")
+        COMPONENT_CACHE_KEY="${{ fromJson(steps.atmos-settings.outputs.settings).components.terraform.command || 'terraform' }}/$(basename "${{ fromJson(steps.atmos-settings.outputs.settings).component-path }}")"
         PLAN_FILE="$( realpath ${COMPONENT_PATH})/$COMPONENT_SLUG-${{ inputs.sha }}.planfile"
         PLAN_FILE_JSON="$( realpath ${COMPONENT_PATH})/$COMPONENT_SLUG-${{ inputs.sha }}.planfile.json"
         LOCK_FILE="$( realpath ${COMPONENT_PATH})/.terraform.lock.hcl"

--- a/action.yml
+++ b/action.yml
@@ -179,7 +179,10 @@ runs:
     - name: Install Dependencies
       uses: cloudposse-github-actions/install-gh-releases@v1
       with:
-        cache: true
+        # TODO revert
+        # testing cache disabled
+        #cache: true
+        cache: false
         config: |-
           hashicorp/terraform:
             tag: ${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).terraform-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).terraform-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).terraform-version) }}

--- a/action.yml
+++ b/action.yml
@@ -181,17 +181,14 @@ runs:
       with:
         cache: true
         config: |-
-          # Install or skip Terraform
-          hashicorp/terraform:
-            tag: ${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).terraform-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).terraform-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).terraform-version) }}
-            skip: ${{ fromJson(steps.atmos-settings.outputs.settings).terraform-version == '' || fromJson(steps.atmos-settings.outputs.settings).terraform-version == 'null' }}
-            extension-matching: true
-          # Install or skip OpenTofu
-          opentofu/opentofu:
-            tag: ${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).opentofu-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).opentofu-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).opentofu-version) }}
-            skip: ${{ fromJson(steps.atmos-settings.outputs.settings).opentofu-version == '' || fromJson(steps.atmos-settings.outputs.settings).opentofu-version == 'null' }}
-          # Always install tfcmt
-          suzuki-shunsuke/tfcmt: v4.14.0
+            hashicorp/terraform:
+              tag: ${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).terraform-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).terraform-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).terraform-version) }}
+              skip: ${{ fromJson(steps.atmos-settings.outputs.settings).terraform-version == '' || fromJson(steps.atmos-settings.outputs.settings).terraform-version == 'null' }}
+              extension-matching: true
+            opentofu/opentofu:
+              tag: ${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).opentofu-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).opentofu-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).opentofu-version) }}
+              skip: ${{ fromJson(steps.atmos-settings.outputs.settings).opentofu-version == '' || fromJson(steps.atmos-settings.outputs.settings).opentofu-version == 'null' }}
+            suzuki-shunsuke/tfcmt: v4.14.0
 
     - name: Configure Plan AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4

--- a/action.yml
+++ b/action.yml
@@ -179,6 +179,14 @@ runs:
     - name: Add Terraform and OpenTofu to Aqua
       shell: bash
       run: |
+        cat << EOF > aqua.yaml
+        registries:
+          - type: standard
+            ref: v4.233.0
+        packages:
+          - name: suzuki-shunsuke/tfcmt@v4.14.5
+        EOF
+
         # Add Terraform if specified
         if [[ "${{ fromJson(steps.atmos-settings.outputs.settings).terraform-version }}" != "" && "${{ fromJson(steps.atmos-settings.outputs.settings).terraform-version }}" != "null" ]]; then
           VERSION="${{ fromJson(steps.atmos-settings.outputs.settings).terraform-version }}"

--- a/action.yml
+++ b/action.yml
@@ -176,18 +176,19 @@ runs:
             settingsPath: settings.integrations.github.gitops.artifact-storage.cosmos-endpoint
             outputPath: cosmos-endpoint
 
+          #hashicorp/terraform:
+          #  tag: ${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).terraform-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).terraform-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).terraform-version) }}
+          #  skip: ${{ fromJson(steps.atmos-settings.outputs.settings).terraform-version == '' || fromJson(steps.atmos-settings.outputs.settings).terraform-version == 'null' }}
     - name: Install Dependencies
       uses: cloudposse-github-actions/install-gh-releases@v1
       with:
         cache: true
         config: |-
-          suzuki-shunsuke/tfcmt: v4.14.0
-          hashicorp/terraform:
-            tag: ${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).terraform-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).terraform-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).terraform-version) }}
-            skip: ${{ fromJson(steps.atmos-settings.outputs.settings).terraform-version == '' || fromJson(steps.atmos-settings.outputs.settings).terraform-version == 'null' }}
+          hashicorp/terraform: latest
           opentofu/opentofu:
             tag: ${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).opentofu-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).opentofu-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).opentofu-version) }}
             skip: ${{ fromJson(steps.atmos-settings.outputs.settings).opentofu-version == '' || fromJson(steps.atmos-settings.outputs.settings).opentofu-version == 'null' }}
+          suzuki-shunsuke/tfcmt: v4.14.0
 
     - name: Configure Plan AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4

--- a/action.yml
+++ b/action.yml
@@ -192,7 +192,7 @@ runs:
         case "${{ runner.architecture }}" in
           X64)   ARCH="amd64" ;;
           ARM64) ARCH="arm64" ;;
-          *)     echo "Unsupported ARCH" >&2; exit 1 ;;
+          *)     echo "Unsupported ARCH: ${{ runner.architecture }}" >&2; exit 1 ;;
         esac
 
         URL="https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_${OS}_${ARCH}.zip"

--- a/action.yml
+++ b/action.yml
@@ -226,7 +226,7 @@ runs:
         aqua_version: v2.50.0
         # Disable "-l", the default option
         # https://aquaproj.github.io/docs/tutorial/install-only-link
-        aqua_args: ""
+        aqua_opts: ""
       env:
         AQUA_CONFIG: /tmp/aqua.yaml
         AQUA_LOG_LEVEL: debug

--- a/action.yml
+++ b/action.yml
@@ -178,31 +178,33 @@ runs:
 
     - name: Install dependencies (Terraform)
       uses: aquaproj/aqua-installer@5e54e5cee8a95ee2ce7c04cb993da6dfad13e59c # v3.1.2
+      if: ${{ fromJson(steps.atmos-settings.outputs.settings).terraform-version != '' && fromJson(steps.atmos-settings.outputs.settings).terraform-version != 'null' }}
       with:
         aqua_version: v2.50.0
-        aqua_opts: "hashicorp/terraform@1.5.2"
+        aqua_opts: "aquaproj/registry-standard/hashicorp/terraform@${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).terraform-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).terraform-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).terraform-version) }}"
       env:
-        AQUA_CONFIG: aqua.yaml
+        #AQUA_CONFIG: aqua.yaml
         AQUA_LOG_LEVEL: debug
 
     - name: Install dependencies (OpenTofu)
       uses: aquaproj/aqua-installer@5e54e5cee8a95ee2ce7c04cb993da6dfad13e59c # v3.1.2
+      if: ${{ fromJson(steps.atmos-settings.outputs.settings).opentofu-version != '' && fromJson(steps.atmos-settings.outputs.settings).opentofu-version != 'null' }}
       with:
         aqua_version: v2.50.0
-        aqua_opts: "opentofu/opentofu@v1.9.1"
+        aqua_opts: "aquaproj/registry-standard/opentofu/opentofu@${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).opentofu-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).opentofu-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).opentofu-version) }}"
+      env:
+        #AQUA_CONFIG: aqua.yaml
+        AQUA_LOG_LEVEL: debug
+
+    - name: Install shared dependencies
+      uses: aquaproj/aqua-installer@5e54e5cee8a95ee2ce7c04cb993da6dfad13e59c # v3.1.2
+      if: ${{ fromJson(steps.atmos-settings.outputs.settings).opentofu-version != '' && fromJson(steps.atmos-settings.outputs.settings).opentofu-version != 'null' }}
+      with:
+        aqua_version: v2.50.0
+        skip_install_aqua: true
       env:
         AQUA_CONFIG: aqua.yaml
         AQUA_LOG_LEVEL: debug
-
-        #- name: Install Dependencies
-        #  uses: cloudposse-github-actions/install-gh-releases@v1
-        #  with:
-        #    cache: true
-        #    config: |-
-        #      opentofu/opentofu:
-        #        tag: ${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).opentofu-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).opentofu-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).opentofu-version) }}
-        #        skip: ${{ fromJson(steps.atmos-settings.outputs.settings).opentofu-version == '' || fromJson(steps.atmos-settings.outputs.settings).opentofu-version == 'null' }}
-        #      suzuki-shunsuke/tfcmt: v4.14.0
 
     - name: Configure Plan AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4

--- a/action.yml
+++ b/action.yml
@@ -176,7 +176,7 @@ runs:
             settingsPath: settings.integrations.github.gitops.artifact-storage.cosmos-endpoint
             outputPath: cosmos-endpoint
 
-    - name: Create aqua config
+    - name: Add Terraform and OpenTofu to Aqua
       shell: bash
       run: |
         # Add Terraform if specified
@@ -194,7 +194,7 @@ runs:
           if [[ ! "$VERSION" =~ ^v ]]; then
             VERSION="v$VERSION"
           fi
-          echo "  - name: /opentofu/opentofu@$VERSION" >> aqua.yaml
+          echo "  - name: opentofu/opentofu@$VERSION" >> aqua.yaml
         fi
 
         # Debug output if debug is enabled
@@ -203,7 +203,7 @@ runs:
           cat aqua.yaml
         fi
 
-    - name: Install dependencies
+    - name: Install dependencies with Aqua
       uses: aquaproj/aqua-installer@5e54e5cee8a95ee2ce7c04cb993da6dfad13e59c # v3.1.2
       with:
         aqua_version: v2.50.0

--- a/action.yml
+++ b/action.yml
@@ -176,15 +176,15 @@ runs:
             settingsPath: settings.integrations.github.gitops.artifact-storage.cosmos-endpoint
             outputPath: cosmos-endpoint
 
-    #hashicorp/terraform:
-    #  tag: ${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).terraform-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).terraform-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).terraform-version) }}
-    #  skip: ${{ fromJson(steps.atmos-settings.outputs.settings).terraform-version == '' || fromJson(steps.atmos-settings.outputs.settings).terraform-version == 'null' }}
     - name: Install Dependencies
       uses: cloudposse-github-actions/install-gh-releases@v1
       with:
         cache: true
         config: |-
-          hashicorp/terraform: latest
+          hashicorp/terraform:
+            tag: ${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).terraform-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).terraform-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).terraform-version) }}
+            skip: ${{ fromJson(steps.atmos-settings.outputs.settings).terraform-version == '' || fromJson(steps.atmos-settings.outputs.settings).terraform-version == 'null' }}
+            extension-matching: true
           opentofu/opentofu:
             tag: ${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).opentofu-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).opentofu-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).opentofu-version) }}
             skip: ${{ fromJson(steps.atmos-settings.outputs.settings).opentofu-version == '' || fromJson(steps.atmos-settings.outputs.settings).opentofu-version == 'null' }}

--- a/action.yml
+++ b/action.yml
@@ -265,7 +265,7 @@ runs:
         COMPONENT_SLUG="$STACK_NAME-$COMPONENT_NAME"
         # We need separate caches for Terraform and OpenTofu!
         # Append the command to the key to ensure different caches for each command.
-        COMPONENT_CACHE_KEY: "${{ fromJson(steps.atmos-settings.outputs.settings).components.terraform.command || 'terraform' }}-$(basename "${{ fromJson(steps.atmos-settings.outputs.settings).component-path }}")"
+        COMPONENT_CACHE_KEY="${{ fromJson(steps.atmos-settings.outputs.settings).components.terraform.command || 'terraform' }}-$(basename ${{ fromJson(steps.atmos-settings.outputs.settings).component-path }})"
         PLAN_FILE="$( realpath ${COMPONENT_PATH})/$COMPONENT_SLUG-${{ inputs.sha }}.planfile"
         PLAN_FILE_JSON="$( realpath ${COMPONENT_PATH})/$COMPONENT_SLUG-${{ inputs.sha }}.planfile.json"
         LOCK_FILE="$( realpath ${COMPONENT_PATH})/.terraform.lock.hcl"

--- a/action.yml
+++ b/action.yml
@@ -176,32 +176,46 @@ runs:
             settingsPath: settings.integrations.github.gitops.artifact-storage.cosmos-endpoint
             outputPath: cosmos-endpoint
 
-    - name: Install dependencies (Terraform)
-      uses: aquaproj/aqua-installer@5e54e5cee8a95ee2ce7c04cb993da6dfad13e59c # v3.1.2
-      if: ${{ fromJson(steps.atmos-settings.outputs.settings).terraform-version != '' && fromJson(steps.atmos-settings.outputs.settings).terraform-version != 'null' }}
-      with:
-        aqua_version: v2.50.0
-        aqua_opts: "aquaproj/registry-standard/hashicorp/terraform@${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).terraform-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).terraform-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).terraform-version) }}"
-      env:
-        AQUA_CONFIG: aqua.yaml
-        AQUA_LOG_LEVEL: debug
+    - name: Create aqua config
+      shell: bash
+      run: |
+        # Read the existing aqua.yaml
+        cat > aqua.yaml << 'EOL'
+        registries:
+          - type: standard
+            ref: v4.233.0 # renovate: depName=aquaproj/aqua-registry
+        packages:
+          - name: suzuki-shunsuke/tfcmt@v4.14.5
+        EOL
 
-    - name: Install dependencies (OpenTofu)
-      uses: aquaproj/aqua-installer@5e54e5cee8a95ee2ce7c04cb993da6dfad13e59c # v3.1.2
-      if: ${{ fromJson(steps.atmos-settings.outputs.settings).opentofu-version != '' && fromJson(steps.atmos-settings.outputs.settings).opentofu-version != 'null' }}
-      with:
-        aqua_version: v2.50.0
-        aqua_opts: "aquaproj/registry-standard/opentofu/opentofu@${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).opentofu-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).opentofu-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).opentofu-version) }}"
-      env:
-        AQUA_CONFIG: aqua.yaml
-        AQUA_LOG_LEVEL: debug
+        # Add Terraform if specified
+        if [[ "${{ fromJson(steps.atmos-settings.outputs.settings).terraform-version }}" != "" && "${{ fromJson(steps.atmos-settings.outputs.settings).terraform-version }}" != "null" ]]; then
+          VERSION="${{ fromJson(steps.atmos-settings.outputs.settings).terraform-version }}"
+          if [[ ! "$VERSION" =~ ^v ]]; then
+            VERSION="v$VERSION"
+          fi
+          echo "          - name: hashicorp/terraform@$VERSION" >> aqua.yaml
+        fi
 
-    - name: Install shared dependencies
+        # Add OpenTofu if specified
+        if [[ "${{ fromJson(steps.atmos-settings.outputs.settings).opentofu-version }}" != "" && "${{ fromJson(steps.atmos-settings.outputs.settings).opentofu-version }}" != "null" ]]; then
+          VERSION="${{ fromJson(steps.atmos-settings.outputs.settings).opentofu-version }}"
+          if [[ ! "$VERSION" =~ ^v ]]; then
+            VERSION="v$VERSION"
+          fi
+          echo "          - name: /opentofu/opentofu@$VERSION" >> aqua.yaml
+        fi
+
+        # Debug output if debug is enabled
+        if [[ "${{ inputs.debug }}" == "true" ]]; then
+          echo "Generated aqua.yaml:"
+          cat aqua.yaml
+        fi
+
+    - name: Install dependencies
       uses: aquaproj/aqua-installer@5e54e5cee8a95ee2ce7c04cb993da6dfad13e59c # v3.1.2
       with:
         aqua_version: v2.50.0
-        skip_install_aqua: true
-        aqua_opts: "aquaproj/registry-standard/suzuki-shunsuke/tfcmt@v4.14.5"
       env:
         AQUA_CONFIG: aqua.yaml
         AQUA_LOG_LEVEL: debug

--- a/action.yml
+++ b/action.yml
@@ -176,18 +176,14 @@ runs:
             settingsPath: settings.integrations.github.gitops.artifact-storage.cosmos-endpoint
             outputPath: cosmos-endpoint
 
-    - name: Install Terraform
-      if: ${{ fromJson(steps.atmos-settings.outputs.settings).terraform-version != '' && fromJson(steps.atmos-settings.outputs.settings).terraform-version != 'null' }}
-      uses: hashicorp/setup-terraform@v3
-      with:
-        terraform_version: ${{ fromJson(steps.atmos-settings.outputs.settings).terraform-version }}
-        terraform_wrapper: false
-
     - name: Install Dependencies
       uses: cloudposse-github-actions/install-gh-releases@v1
       with:
         cache: true
         config: |-
+          hashicorp/terraform:
+            tag: ${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).terraform-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).terraform-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).terraform-version) }}
+            skip: ${{ fromJson(steps.atmos-settings.outputs.settings).terraform-version == '' || fromJson(steps.atmos-settings.outputs.settings).terraform-version == 'null' }}
           opentofu/opentofu:
             tag: ${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).opentofu-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).opentofu-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).opentofu-version) }}
             skip: ${{ fromJson(steps.atmos-settings.outputs.settings).opentofu-version == '' || fromJson(steps.atmos-settings.outputs.settings).opentofu-version == 'null' }}

--- a/action.yml
+++ b/action.yml
@@ -367,14 +367,9 @@ runs:
           grep -Pzo '(?<=_______________ISSUE-MARKDOWN_______________\n)(.|\n)*' ${{ steps.vars.outputs.summary_file }} | grep -Pav  "\x00" > ${{ steps.vars.outputs.issue_file }}
           # Clean up original file since content is now split
           rm -f ${{ steps.vars.outputs.summary_file }}
-        else
+        elif [ -f "${{ steps.vars.outputs.summary_file }}" ]; then
           # In normal mode, safely move the summary to step summary location if it exists
-          if [ -f "${{ steps.vars.outputs.summary_file }}" ]; then
-            mv "${{ steps.vars.outputs.summary_file }}" "${{ steps.vars.outputs.step_summary_file }}"
-          else
-            # If summary file doesn't exist (e.g., when pr-comment is true), create an empty step summary
-            touch "${{ steps.vars.outputs.step_summary_file }}"
-          fi
+          mv "${{ steps.vars.outputs.summary_file }}" "${{ steps.vars.outputs.step_summary_file }}"
         fi
 
         cat "${TERRAFORM_OUTPUT_FILE}"

--- a/action.yml
+++ b/action.yml
@@ -196,7 +196,6 @@ runs:
 
     - name: Install shared dependencies
       uses: aquaproj/aqua-installer@5e54e5cee8a95ee2ce7c04cb993da6dfad13e59c # v3.1.2
-      if: ${{ fromJson(steps.atmos-settings.outputs.settings).opentofu-version != '' && fromJson(steps.atmos-settings.outputs.settings).opentofu-version != 'null' }}
       with:
         aqua_version: v2.50.0
         skip_install_aqua: true

--- a/action.yml
+++ b/action.yml
@@ -306,6 +306,9 @@ runs:
 
         TERRAFORM_OUTPUT_FILE="./terraform-${GITHUB_RUN_ID}-output.txt"
 
+        # Create the directory for the summary file if it doesn't exist
+        mkdir -p "$(dirname "${{ steps.vars.outputs.summary_file }}")"
+
         tfcmt \
         --config ${GITHUB_ACTION_PATH}/config/summary.yaml \
         -owner "${{ github.repository_owner }}" \

--- a/action.yml
+++ b/action.yml
@@ -224,8 +224,7 @@ runs:
       uses: aquaproj/aqua-installer@5e54e5cee8a95ee2ce7c04cb993da6dfad13e59c # v3.1.2
       with:
         aqua_version: v2.50.0
-        # Disable "-l", the default option
-        # https://aquaproj.github.io/docs/tutorial/install-only-link
+        # Disable "-l", the default option: https://aquaproj.github.io/docs/tutorial/install-only-link
         aqua_opts: ""
       env:
         AQUA_CONFIG: /tmp/aqua.yaml

--- a/action.yml
+++ b/action.yml
@@ -263,7 +263,7 @@ runs:
         COMPONENT_PATH=${{ fromJson(steps.atmos-settings.outputs.settings).component-path }}
         COMPONENT_NAME=$(echo "${{ inputs.component }}" | sed 's#/#_#g')
         COMPONENT_SLUG="$STACK_NAME-$COMPONENT_NAME"
-        COMPONENT_CACHE_KEY="${{ fromJson(steps.atmos-settings.outputs.settings).components.terraform.command || 'terraform' }}/$(basename "${{ fromJson(steps.atmos-settings.outputs.settings).component-path }}")"
+        COMPONENT_CACHE_KEY=$(basename "${{ fromJson(steps.atmos-settings.outputs.settings).component-path }}")
         PLAN_FILE="$( realpath ${COMPONENT_PATH})/$COMPONENT_SLUG-${{ inputs.sha }}.planfile"
         PLAN_FILE_JSON="$( realpath ${COMPONENT_PATH})/$COMPONENT_SLUG-${{ inputs.sha }}.planfile.json"
         LOCK_FILE="$( realpath ${COMPONENT_PATH})/.terraform.lock.hcl"
@@ -292,7 +292,9 @@ runs:
       with:
         path: |
           ./${{ steps.vars.outputs.component_path }}/.terraform
-        key: ${{ steps.vars.outputs.cache-key }}
+        # We need separate caches for Terraform and OpenTofu!
+        # Append the command to the key to ensure different caches for each command.
+        key: "${{ fromJson(steps.atmos-settings.outputs.settings).components.terraform.command || 'terraform' }}/${{ steps.vars.outputs.cache-key }}"
 
     - name: Atmos Terraform Plan
       if: ${{ fromJson(steps.atmos-settings.outputs.settings).enabled }}

--- a/action.yml
+++ b/action.yml
@@ -179,22 +179,13 @@ runs:
     - name: Create aqua config
       shell: bash
       run: |
-        # Read the existing aqua.yaml
-        cat > aqua.yaml << 'EOL'
-        registries:
-          - type: standard
-            ref: v4.233.0 # renovate: depName=aquaproj/aqua-registry
-        packages:
-          - name: suzuki-shunsuke/tfcmt@v4.14.5
-        EOL
-
         # Add Terraform if specified
         if [[ "${{ fromJson(steps.atmos-settings.outputs.settings).terraform-version }}" != "" && "${{ fromJson(steps.atmos-settings.outputs.settings).terraform-version }}" != "null" ]]; then
           VERSION="${{ fromJson(steps.atmos-settings.outputs.settings).terraform-version }}"
           if [[ ! "$VERSION" =~ ^v ]]; then
             VERSION="v$VERSION"
           fi
-          echo "          - name: hashicorp/terraform@$VERSION" >> aqua.yaml
+          echo "  - name: hashicorp/terraform@$VERSION" >> aqua.yaml
         fi
 
         # Add OpenTofu if specified
@@ -203,7 +194,7 @@ runs:
           if [[ ! "$VERSION" =~ ^v ]]; then
             VERSION="v$VERSION"
           fi
-          echo "          - name: /opentofu/opentofu@$VERSION" >> aqua.yaml
+          echo "  - name: /opentofu/opentofu@$VERSION" >> aqua.yaml
         fi
 
         # Debug output if debug is enabled

--- a/action.yml
+++ b/action.yml
@@ -183,6 +183,7 @@ runs:
         aqua_version: v2.50.0
         aqua_opts: "-l aquaproj/registry-standard/hashicorp/terraform@${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).terraform-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).terraform-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).terraform-version) }}"
       env:
+        AQUA_CONFIG: aqua.yaml
         AQUA_LOG_LEVEL: debug
 
     - name: Install dependencies (OpenTofu)
@@ -192,6 +193,7 @@ runs:
         aqua_version: v2.50.0
         aqua_opts: "-l aquaproj/registry-standard/opentofu/opentofu@${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).opentofu-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).opentofu-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).opentofu-version) }}"
       env:
+        AQUA_CONFIG: aqua.yaml
         AQUA_LOG_LEVEL: debug
 
     - name: Install shared dependencies
@@ -201,6 +203,7 @@ runs:
         skip_install_aqua: true
         aqua_opts: "-l aquaproj/registry-standard/suzuki-shunsuke/tfcmt@v4.14.5"
       env:
+        AQUA_CONFIG: aqua.yaml
         AQUA_LOG_LEVEL: debug
 
     - name: Configure Plan AWS Credentials

--- a/action.yml
+++ b/action.yml
@@ -181,7 +181,7 @@ runs:
       if: ${{ fromJson(steps.atmos-settings.outputs.settings).terraform-version != '' && fromJson(steps.atmos-settings.outputs.settings).terraform-version != 'null' }}
       with:
         aqua_version: v2.50.0
-        aqua_opts: "-l aquaproj/registry-standard/hashicorp/terraform@${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).terraform-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).terraform-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).terraform-version) }}"
+        aqua_opts: "aquaproj/registry-standard/hashicorp/terraform@${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).terraform-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).terraform-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).terraform-version) }}"
       env:
         AQUA_CONFIG: aqua.yaml
         AQUA_LOG_LEVEL: debug
@@ -191,7 +191,7 @@ runs:
       if: ${{ fromJson(steps.atmos-settings.outputs.settings).opentofu-version != '' && fromJson(steps.atmos-settings.outputs.settings).opentofu-version != 'null' }}
       with:
         aqua_version: v2.50.0
-        aqua_opts: "-l aquaproj/registry-standard/opentofu/opentofu@${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).opentofu-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).opentofu-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).opentofu-version) }}"
+        aqua_opts: "aquaproj/registry-standard/opentofu/opentofu@${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).opentofu-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).opentofu-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).opentofu-version) }}"
       env:
         AQUA_CONFIG: aqua.yaml
         AQUA_LOG_LEVEL: debug
@@ -201,7 +201,7 @@ runs:
       with:
         aqua_version: v2.50.0
         skip_install_aqua: true
-        aqua_opts: "-l aquaproj/registry-standard/suzuki-shunsuke/tfcmt@v4.14.5"
+        aqua_opts: "aquaproj/registry-standard/suzuki-shunsuke/tfcmt@v4.14.5"
       env:
         AQUA_CONFIG: aqua.yaml
         AQUA_LOG_LEVEL: debug

--- a/action.yml
+++ b/action.yml
@@ -199,7 +199,7 @@ runs:
       with:
         aqua_version: v2.50.0
         skip_install_aqua: true
-        aqua_opts: "-l suzuki-shunsuke/tfcmt@v4.14.5"
+        aqua_opts: "-l aquaproj/registry-standard/suzuki-shunsuke/tfcmt@v4.14.5"
       env:
         AQUA_LOG_LEVEL: debug
 

--- a/action.yml
+++ b/action.yml
@@ -299,8 +299,6 @@ runs:
       id: atmos-plan
       shell: bash
       run: |
-        set +e
-
         # Remove the environment file from the cache to avoid conflicts with workspace select
         rm -f ./${{ steps.vars.outputs.component_path }}/.terraform/environment
 
@@ -309,6 +307,17 @@ runs:
         # Create the directory for the summary file if it doesn't exist
         mkdir -p "$(dirname "${{ steps.vars.outputs.summary_file }}")"
 
+        # Debug tfcmt
+        if [[ "${{ inputs.debug }}" == "true" ]]; then
+          echo "Debug tfcmt"
+          tfcmt --version
+        fi
+
+        # Disable exit on error so we can capture the terraform exit code
+        # and handle it appropriately later in the script
+        set +e
+
+        # Run tfcmt, atmos, and terraform to create the plan file
         tfcmt \
         --config ${GITHUB_ACTION_PATH}/config/summary.yaml \
         -owner "${{ github.repository_owner }}" \
@@ -338,12 +347,10 @@ runs:
 
         TERRAFORM_RESULT=$?
     
-        if [[ "${{ inputs.debug }}" == "true" ]]; then
-          echo "tfcmt exit code: $?"
-          ls -l "${{ steps.vars.outputs.summary_file }}" || echo "summary file not found"
-          cat ${TERRAFORM_OUTPUT_FILE}
-        fi
+        # Re-enable exit on error
+        set -e
 
+        # If we have comments enabled, we need to run tfcmt again to create a different summary file
         if [[ "${{ inputs.pr-comment }}" == "true" ]]; then
           tfcmt \
           --config ${GITHUB_ACTION_PATH}/config/summary.yaml \
@@ -366,8 +373,8 @@ runs:
             bash -c "cat ${TERRAFORM_OUTPUT_FILE}"
         fi
 
-        set -e
-
+        # If we have drift detection enabled, we need to split the summary file into 2 files
+        # If we dont, we just move the summary file to the step summary file
         if [[ "${{ inputs.drift-detection-mode-enabled }}" == "true" ]]; then
           # Split summary to 2 files - issue and step summary files
           # Remove \0 at the end of the grep output

--- a/action.yml
+++ b/action.yml
@@ -176,30 +176,13 @@ runs:
             settingsPath: settings.integrations.github.gitops.artifact-storage.cosmos-endpoint
             outputPath: cosmos-endpoint
 
-    - name: Install Terraform
-      if: ${{ fromJson(steps.atmos-settings.outputs.settings).terraform-version != '' && fromJson(steps.atmos-settings.outputs.settings).terraform-version != 'null' }}
-      shell: bash
-      run: |
-        set -eux
-
-        # Pin your version here
-        TERRAFORM_VERSION="${{ startsWith(fromJson(steps.atmos-settings.outputs.settings).terraform-version, 'v') && fromJson(steps.atmos-settings.outputs.settings).terraform-version || format('v{0}', fromJson(steps.atmos-settings.outputs.settings).terraform-version) }}"
-
-        # Map runner.os → lowercase (linux, darwin, windows)
-        OS="$(echo "${{ runner.os }}" | tr '[:upper:]' '[:lower:]')"
-
-        # Map runner.architecture → terraform's naming
-        case "${{ runner.architecture }}" in
-          X64)   ARCH="amd64" ;;
-          ARM64) ARCH="arm64" ;;
-          *)     echo "Unsupported ARCH: ${{ runner.architecture }}" >&2; exit 1 ;;
-        esac
-
-        URL="https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_${OS}_${ARCH}.zip"
-
-        curl -fsSL "$URL" -o terraform.zip
-        unzip terraform.zip
-        sudo mv terraform /usr/local/bin/
+    - name: Install dependencies
+      uses: aquaproj/aqua-installer@5e54e5cee8a95ee2ce7c04cb993da6dfad13e59c # v3.1.2
+      with:
+        aqua_version: v2.50.0
+      env:
+        AQUA_CONFIG: aqua.yaml
+        AQUA_LOG_LEVEL: debug
 
     - name: Install Dependencies
       uses: cloudposse-github-actions/install-gh-releases@v1

--- a/action.yml
+++ b/action.yml
@@ -287,14 +287,14 @@ runs:
 
     - name: Cache .terraform
       id: cache
-      uses: actions/cache@v4
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       if: ${{ fromJson(steps.atmos-settings.outputs.settings).enabled }}
       with:
         path: |
           ./${{ steps.vars.outputs.component_path }}/.terraform
         # We need separate caches for Terraform and OpenTofu!
         # Append the command to the key to ensure different caches for each command.
-        key: "${{ fromJson(steps.atmos-settings.outputs.settings).components.terraform.command || 'terraform' }}/${{ steps.vars.outputs.cache-key }}"
+        key: ${{ fromJson(steps.atmos-settings.outputs.settings).components.terraform.command || 'terraform' }}-${{ steps.vars.outputs.cache-key }}
 
     - name: Atmos Terraform Plan
       if: ${{ fromJson(steps.atmos-settings.outputs.settings).enabled }}

--- a/action.yml
+++ b/action.yml
@@ -263,7 +263,7 @@ runs:
         COMPONENT_PATH=${{ fromJson(steps.atmos-settings.outputs.settings).component-path }}
         COMPONENT_NAME=$(echo "${{ inputs.component }}" | sed 's#/#_#g')
         COMPONENT_SLUG="$STACK_NAME-$COMPONENT_NAME"
-        COMPONENT_CACHE_KEY="${{ fromJson(steps.atmos-settings.outputs.settings).components.terraform.command || 'terraform' }}-$(basename ${{ fromJson(steps.atmos-settings.outputs.settings).component-path }})"
+        COMPONENT_CACHE_KEY="$(basename ${{ fromJson(steps.atmos-settings.outputs.settings).component-path }})"
         PLAN_FILE="$( realpath ${COMPONENT_PATH})/$COMPONENT_SLUG-${{ inputs.sha }}.planfile"
         PLAN_FILE_JSON="$( realpath ${COMPONENT_PATH})/$COMPONENT_SLUG-${{ inputs.sha }}.planfile.json"
         LOCK_FILE="$( realpath ${COMPONENT_PATH})/.terraform.lock.hcl"

--- a/action.yml
+++ b/action.yml
@@ -263,7 +263,7 @@ runs:
         COMPONENT_PATH=${{ fromJson(steps.atmos-settings.outputs.settings).component-path }}
         COMPONENT_NAME=$(echo "${{ inputs.component }}" | sed 's#/#_#g')
         COMPONENT_SLUG="$STACK_NAME-$COMPONENT_NAME"
-        COMPONENT_CACHE_KEY="$(basename ${{ fromJson(steps.atmos-settings.outputs.settings).component-path }})"
+        COMPONENT_CACHE_KEY=$(basename "${{ fromJson(steps.atmos-settings.outputs.settings).component-path }}")
         PLAN_FILE="$( realpath ${COMPONENT_PATH})/$COMPONENT_SLUG-${{ inputs.sha }}.planfile"
         PLAN_FILE_JSON="$( realpath ${COMPONENT_PATH})/$COMPONENT_SLUG-${{ inputs.sha }}.planfile.json"
         LOCK_FILE="$( realpath ${COMPONENT_PATH})/.terraform.lock.hcl"
@@ -365,7 +365,7 @@ runs:
           grep -Pzo '(.|\n)*(?=_______________ISSUE-MARKDOWN_______________\n)' ${{ steps.vars.outputs.summary_file }} | grep -Pav  "\x00" > ${{ steps.vars.outputs.step_summary_file }}
           grep -Pzo '(?<=_______________ISSUE-MARKDOWN_______________\n)(.|\n)*' ${{ steps.vars.outputs.summary_file }} | grep -Pav  "\x00" > ${{ steps.vars.outputs.issue_file }}
           rm -f ${{ steps.vars.outputs.summary_file }}
-        elif [[ "${{ inputs.pr-comment }}" == "true" ]]; then
+        else
           mv ${{ steps.vars.outputs.summary_file }} ${{ steps.vars.outputs.step_summary_file }}
         fi
 

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -1,5 +1,0 @@
-registries:
-  - type: standard
-    ref: v4.233.0 # renovate: depName=aquaproj/aqua-registry
-packages:
-  - name: suzuki-shunsuke/tfcmt@v4.14.5

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -1,7 +1,0 @@
-registries:
-  - type: standard
-    ref: v4.233.0  # renovate: depName=aquaproj/aqua-registry
-
-packages:
-  - name: suzuki-shunsuke/tfcmt@v4.14.5
-

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -1,0 +1,3 @@
+registries:
+  - type: standard
+    ref: v4.233.0 # renovate: depName=aquaproj/aqua-registry

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -1,3 +1,5 @@
 registries:
   - type: standard
     ref: v4.233.0 # renovate: depName=aquaproj/aqua-registry
+packages:
+  - name: suzuki-shunsuke/tfcmt@v4.14.5

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -1,0 +1,7 @@
+registries:
+  - type: standard
+    ref: v4.233.0  # renovate: depName=aquaproj/aqua-registry
+
+packages:
+  - name: hashicorp/terraform@v1.5.2
+

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -3,5 +3,5 @@ registries:
     ref: v4.233.0  # renovate: depName=aquaproj/aqua-registry
 
 packages:
-  - name: hashicorp/terraform@v1.5.2
+  - name: suzuki-shunsuke/tfcmt@v4.14.5
 


### PR DESCRIPTION
## what
- ~~Replaced `hashicorp/setup-terraform` action with `cloudposse-github-actions/install-gh-releases` for Terraform installation~~
- Install Terraform, OpenTofu, and tfcmt with Aqua

## why
- `hashicorp/setup-terraform` has a intermittent issue on self-hosted runners with firewalls. See the connected issue
- We need to replace the Terraform installation method to fix the installation
- Since hashicorp does not publish the binary, we cannot use [cloudposse-github-actions/install-gh-releases](https://github.com/cloudposse-github-actions/install-gh-releases)
- We should also use Aqua to install OpenTofu and tfcmt for consistency sake

## references
- https://aquaproj.github.io/docs/
- https://github.com/hashicorp/setup-terraform/issues/425