### PR TITLE
Disable process functions

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -56,6 +56,5 @@ jobs:
           component: "foobar"
           stack: "plat-ue2-sandbox"
           atmos-config-path: ${{ runner.temp }}
-          atmos-version: 1.99.0
           skip-checkout: true
           debug: true

--- a/.github/workflows/test-changes-exists-drift.yml
+++ b/.github/workflows/test-changes-exists-drift.yml
@@ -63,7 +63,6 @@ jobs:
           sha: ${{ github.sha }}
           drift-detection-mode-enabled: true
           atmos-config-path: ${{ runner.temp }}
-          atmos-version: 1.99.0
           skip-checkout: true
 
     outputs:

--- a/.github/workflows/test-changes-exists.yml
+++ b/.github/workflows/test-changes-exists.yml
@@ -63,7 +63,7 @@ jobs:
           stack: "plat-ue2-sandbox"
           sha: ${{ github.sha }}
           atmos-config-path: ${{ runner.temp }}
-          atmos-version: 1.99.0
+          atmos-version: 1.174.0
           skip-checkout: false
 
     outputs:

--- a/.github/workflows/test-changes-exists.yml
+++ b/.github/workflows/test-changes-exists.yml
@@ -63,7 +63,6 @@ jobs:
           stack: "plat-ue2-sandbox"
           sha: ${{ github.sha }}
           atmos-config-path: ${{ runner.temp }}
-          atmos-version: 1.174.0
           skip-checkout: false
 
     outputs:

--- a/.github/workflows/test-failed-plan-drift.yml
+++ b/.github/workflows/test-failed-plan-drift.yml
@@ -63,7 +63,6 @@ jobs:
           sha: ${{ github.sha }}
           drift-detection-mode-enabled: true
           atmos-config-path: ${{ runner.temp }}
-          atmos-version: 1.99.0
           skip-checkout: true
 
     outputs:

--- a/.github/workflows/test-failed-plan-drift.yml
+++ b/.github/workflows/test-failed-plan-drift.yml
@@ -201,7 +201,7 @@ jobs:
               "component": "foobar-fail",
               "stack": "plat-ue2-sandbox",
               "componentPath": "tests/terraform/components/terraform/foobar",
-              "commitSHA": "1d1fe7321b518b111d305dadaff2fd8f895bdc21"
+              "commitSHA": "${{ github.sha }}"
             }
             ```
             </details>

--- a/.github/workflows/test-failed-plan-drift.yml
+++ b/.github/workflows/test-failed-plan-drift.yml
@@ -135,7 +135,8 @@ jobs:
       - uses: nick-fields/assert-action@v2
         with:
           comparison: contains          
-          actual: "${{ fromJSON(needs.test.outputs.summary) }}"
+          actual: |
+            ${{ fromJSON(needs.test.outputs.summary) }}
           expected: |
           
             ## Drift Detection Failed for `foobar-fail` in `plat-ue2-sandbox`!

--- a/.github/workflows/test-failed-plan-drift.yml
+++ b/.github/workflows/test-failed-plan-drift.yml
@@ -139,65 +139,68 @@ jobs:
           expected: |
           
             ## Drift Detection Failed for `foobar-fail` in `plat-ue2-sandbox`!
-            
-            
-            
+
+
+
             <a href="https://cloudposse.com/"><img src="https://cloudposse.com/logo-300x69.svg" width="100px" align="right"/></a>
-            
-            
+
+
             [![failed](https://shields.io/badge/PLAN-FAILED-ff0000?style=for-the-badge)](#user-content-result-plat-ue2-sandbox-foobar-fail)
-            
-            
-            
-            
-            
+
+
+
+
+
             <details><summary><a id="result-plat-ue2-sandbox-foobar-fail" />:warning: Error summary</summary>
-            
+
             <br/>      
             To reproduce this locally, run:<br/><br/>
-            
+
             ```shell
             atmos terraform plan foobar-fail -s plat-ue2-sandbox
             ```
-            
+
             ---
-            
+
             ```hcl
             Error: Invalid function argument
-            
+
               on main.tf line 17, in locals:
               17:   failure = var.enabled && var.enable_failure ? file("Failed because failure mode is enabled") : null
                 ├────────────────
                 │ while calling file(path)
-            
+
             Invalid value for "path" parameter: no file exists at "Failed because failure
             mode is enabled"; this function works only with files that are distributed as
             part of the configuration source code, so if this file will be created by a
             resource in this configuration you must instead obtain this result from an
             attribute of that resource.
+
+            # Error                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
             exit status 1
             ```
-            
+
                 
-            
-            
+
+
                 
             </details>
-            
-            
+
+
                   
-            
-            
-            
-            
+
+
+
+
             <details><summary>Metadata</summary>
-            
+
             ```json
             {
               "component": "foobar-fail",
               "stack": "plat-ue2-sandbox",
               "componentPath": "tests/terraform/components/terraform/foobar",
-              "commitSHA": "${{ github.sha }}"
+              "commitSHA": "1d1fe7321b518b111d305dadaff2fd8f895bdc21"
             }
             ```
             </details>

--- a/.github/workflows/test-failed-plan-drift.yml
+++ b/.github/workflows/test-failed-plan-drift.yml
@@ -134,6 +134,7 @@ jobs:
 
       - uses: nick-fields/assert-action@v2
         with:
+          comparison: contains          
           actual: "${{ fromJSON(needs.test.outputs.summary) }}"
           expected: |
             ## Drift Detection Failed for `foobar-fail` in `plat-ue2-sandbox`!

--- a/.github/workflows/test-failed-plan-drift.yml
+++ b/.github/workflows/test-failed-plan-drift.yml
@@ -137,6 +137,7 @@ jobs:
           comparison: contains          
           actual: "${{ fromJSON(needs.test.outputs.summary) }}"
           expected: |
+          
             ## Drift Detection Failed for `foobar-fail` in `plat-ue2-sandbox`!
             
             

--- a/.github/workflows/test-failed-plan.yml
+++ b/.github/workflows/test-failed-plan.yml
@@ -103,18 +103,6 @@ jobs:
               
             [![failed](https://shields.io/badge/PLAN-FAILED-ff0000?style=for-the-badge)](#user-content-result-plat-ue2-sandbox-foobar-fail)
 
-
-
-            <details><summary><a id="result-plat-ue2-sandbox-foobar-fail" />:warning: Error summary</summary>
-
-            <br/>      
-            To reproduce this locally, run:<br/><br/>
-
-            ```shell
-            atmos terraform plan foobar-fail -s plat-ue2-sandbox
-            ```
-
-
   teardown:
     runs-on: ubuntu-latest
     needs: [assert]

--- a/.github/workflows/test-failed-plan.yml
+++ b/.github/workflows/test-failed-plan.yml
@@ -62,6 +62,7 @@ jobs:
           stack: "plat-ue2-sandbox"
           sha: ${{ github.sha }}
           atmos-config-path: ${{ runner.temp }}
+          atmos-version: 1.145.0
           skip-checkout: true
 
     outputs:

--- a/.github/workflows/test-failed-plan.yml
+++ b/.github/workflows/test-failed-plan.yml
@@ -95,7 +95,8 @@ jobs:
       - uses: nick-fields/assert-action@v2
         with:
           comparison: contains
-          actual: "${{ fromJSON(needs.test.outputs.summary) }}"
+          actual: |-
+            ${{ fromJSON(needs.test.outputs.summary) }}
           expected: |-
             ## Plan Failed for `foobar-fail` in `plat-ue2-sandbox`
               

--- a/.github/workflows/test-failed-plan.yml
+++ b/.github/workflows/test-failed-plan.yml
@@ -95,9 +95,9 @@ jobs:
       - uses: nick-fields/assert-action@v2
         with:
           comparison: contains
-          actual: |-
+          actual: |
             ${{ fromJSON(needs.test.outputs.summary) }}
-          expected: |-
+          expected: |
             ## Plan Failed for `foobar-fail` in `plat-ue2-sandbox`
               
             <a href="https://cloudposse.com/"><img src="https://cloudposse.com/logo-300x69.svg" width="100px" align="right"/></a>

--- a/.github/workflows/test-failed-plan.yml
+++ b/.github/workflows/test-failed-plan.yml
@@ -94,7 +94,7 @@ jobs:
 
       - uses: nick-fields/assert-action@v2
         with:
-          actual: "${{ fromJSON(needs.test.outputs.summary) }}"
+          actual: "^${{ fromJSON(needs.test.outputs.summary) }}^"
           expected: |-
             ## Plan Failed for `foobar-fail` in `plat-ue2-sandbox`
 

--- a/.github/workflows/test-failed-plan.yml
+++ b/.github/workflows/test-failed-plan.yml
@@ -99,6 +99,8 @@ jobs:
             ${{ fromJSON(needs.test.outputs.summary) }}
           expected: |-
             ## Plan Failed for `foobar-fail` in `plat-ue2-sandbox`
+              
+            <a href="https://cloudposse.com/"><img src="https://cloudposse.com/logo-300x69.svg" width="100px" align="right"/></a>
 
   teardown:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-failed-plan.yml
+++ b/.github/workflows/test-failed-plan.yml
@@ -96,7 +96,7 @@ jobs:
         with:
           comparison: contains
           actual: "${{ fromJSON(needs.test.outputs.summary) }}"
-          expected: |-
+          expected: |
             ## Plan Failed for `foobar-fail` in `plat-ue2-sandbox`
               
             <a href="https://cloudposse.com/"><img src="https://cloudposse.com/logo-300x69.svg" width="100px" align="right"/></a>

--- a/.github/workflows/test-failed-plan.yml
+++ b/.github/workflows/test-failed-plan.yml
@@ -62,7 +62,7 @@ jobs:
           stack: "plat-ue2-sandbox"
           sha: ${{ github.sha }}
           atmos-config-path: ${{ runner.temp }}
-          atmos-version: 1.170.0
+          atmos-version: 1.165.0
           skip-checkout: true
 
     outputs:
@@ -99,44 +99,41 @@ jobs:
             ## Plan Failed for `foobar-fail` in `plat-ue2-sandbox`
 
             <a href="https://cloudposse.com/"><img src="https://cloudposse.com/logo-300x69.svg" width="100px" align="right"/></a>
-
+            
             [![failed](https://shields.io/badge/PLAN-FAILED-ff0000?style=for-the-badge)](#user-content-result-plat-ue2-sandbox-foobar-fail)
-
-
-
+            
+            
+            
             <details><summary><a id="result-plat-ue2-sandbox-foobar-fail" />:warning: Error summary</summary>
-
+            
             <br/>      
             To reproduce this locally, run:<br/><br/>
-
+            
             ```shell
             atmos terraform plan foobar-fail -s plat-ue2-sandbox
             ```
-
+            
             ---
-
+            
             ```hcl
             Error: Invalid function argument
-
+            
               on main.tf line 17, in locals:
               17:   failure = var.enabled && var.enable_failure ? file("Failed because failure mode is enabled") : null
                 ├────────────────
                 │ while calling file(path)
-
+            
             Invalid value for "path" parameter: no file exists at "Failed because failure
             mode is enabled"; this function works only with files that are distributed as
             part of the configuration source code, so if this file will be created by a
             resource in this configuration you must instead obtain this result from an
             attribute of that resource.
-
-            # Error                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
             exit status 1
             ```
-
+            
                 
-
-
+            
+            
                 
             </details>
 

--- a/.github/workflows/test-failed-plan.yml
+++ b/.github/workflows/test-failed-plan.yml
@@ -62,7 +62,7 @@ jobs:
           stack: "plat-ue2-sandbox"
           sha: ${{ github.sha }}
           atmos-config-path: ${{ runner.temp }}
-          atmos-version: 1.160.0
+          atmos-version: 1.170.0
           skip-checkout: true
 
     outputs:

--- a/.github/workflows/test-failed-plan.yml
+++ b/.github/workflows/test-failed-plan.yml
@@ -100,8 +100,48 @@ jobs:
           expected: |
           
             ## Plan Failed for `foobar-fail` in `plat-ue2-sandbox`
-            
+
             <a href="https://cloudposse.com/"><img src="https://cloudposse.com/logo-300x69.svg" width="100px" align="right"/></a>
+
+            [![failed](https://shields.io/badge/PLAN-FAILED-ff0000?style=for-the-badge)](#user-content-result-plat-ue2-sandbox-foobar-fail)
+
+
+
+            <details><summary><a id="result-plat-ue2-sandbox-foobar-fail" />:warning: Error summary</summary>
+
+            <br/>      
+            To reproduce this locally, run:<br/><br/>
+
+            ```shell
+            atmos terraform plan foobar-fail -s plat-ue2-sandbox
+            ```
+
+            ---
+
+            ```hcl
+            Error: Invalid function argument
+
+              on main.tf line 17, in locals:
+              17:   failure = var.enabled && var.enable_failure ? file("Failed because failure mode is enabled") : null
+                ├────────────────
+                │ while calling file(path)
+
+            Invalid value for "path" parameter: no file exists at "Failed because failure
+            mode is enabled"; this function works only with files that are distributed as
+            part of the configuration source code, so if this file will be created by a
+            resource in this configuration you must instead obtain this result from an
+            attribute of that resource.
+
+            # Error                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+            exit status 1
+            ```
+
+                
+
+
+                
+            </details>
 
   teardown:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-failed-plan.yml
+++ b/.github/workflows/test-failed-plan.yml
@@ -95,52 +95,9 @@ jobs:
       - uses: nick-fields/assert-action@v2
         with:
           comparison: contains
-          expected: "${{ fromJSON(needs.test.outputs.summary) }}"
-          actual: |
-          
+          actual: "${{ fromJSON(needs.test.outputs.summary) }}"
+          expected: |-
             ## Plan Failed for `foobar-fail` in `plat-ue2-sandbox`
-              
-            <a href="https://cloudposse.com/"><img src="https://cloudposse.com/logo-300x69.svg" width="100px" align="right"/></a>
-              
-            [![failed](https://shields.io/badge/PLAN-FAILED-ff0000?style=for-the-badge)](#user-content-result-plat-ue2-sandbox-foobar-fail)
-
-
-
-            <details><summary><a id="result-plat-ue2-sandbox-foobar-fail" />:warning: Error summary</summary>
-
-            <br/>      
-            To reproduce this locally, run:<br/><br/>
-
-            ```shell
-            atmos terraform plan foobar-fail -s plat-ue2-sandbox
-            ```
-
-            ---
-
-            ```hcl
-            Error: Invalid function argument
-
-              on main.tf line 17, in locals:
-              17:   failure = var.enabled && var.enable_failure ? file("Failed because failure mode is enabled") : null
-                ├────────────────
-                │ while calling file(path)
-
-            Invalid value for "path" parameter: no file exists at "Failed because failure
-            mode is enabled"; this function works only with files that are distributed as
-            part of the configuration source code, so if this file will be created by a
-            resource in this configuration you must instead obtain this result from an
-            attribute of that resource.
-
-            # Error                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
-            exit status 1
-            ```
-
-                
-
-
-                
-            </details>
 
   teardown:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-failed-plan.yml
+++ b/.github/workflows/test-failed-plan.yml
@@ -96,7 +96,7 @@ jobs:
         with:
           comparison: contains
           actual: "${{ fromJSON(needs.test.outputs.summary) }}"
-          expected: |
+          expected: |-
             ## Plan Failed for `foobar-fail` in `plat-ue2-sandbox`
               
             <a href="https://cloudposse.com/"><img src="https://cloudposse.com/logo-300x69.svg" width="100px" align="right"/></a>

--- a/.github/workflows/test-failed-plan.yml
+++ b/.github/workflows/test-failed-plan.yml
@@ -95,47 +95,77 @@ jobs:
       - uses: nick-fields/assert-action@v2
         with:
           actual: "${{ fromJSON(needs.test.outputs.summary) }}"
-          expected: |-
+          expected: |
             ## Plan Failed for `foobar-fail` in `plat-ue2-sandbox`
 
             <a href="https://cloudposse.com/"><img src="https://cloudposse.com/logo-300x69.svg" width="100px" align="right"/></a>
-            
+
             [![failed](https://shields.io/badge/PLAN-FAILED-ff0000?style=for-the-badge)](#user-content-result-plat-ue2-sandbox-foobar-fail)
-            
-            
-            
+
+
+
             <details><summary><a id="result-plat-ue2-sandbox-foobar-fail" />:warning: Error summary</summary>
-            
+
             <br/>      
             To reproduce this locally, run:<br/><br/>
-            
+
             ```shell
             atmos terraform plan foobar-fail -s plat-ue2-sandbox
             ```
-            
+
             ---
-            
+
             ```hcl
             Error: Invalid function argument
-            
+
               on main.tf line 17, in locals:
               17:   failure = var.enabled && var.enable_failure ? file("Failed because failure mode is enabled") : null
                 ├────────────────
                 │ while calling file(path)
-            
+
             Invalid value for "path" parameter: no file exists at "Failed because failure
             mode is enabled"; this function works only with files that are distributed as
             part of the configuration source code, so if this file will be created by a
             resource in this configuration you must instead obtain this result from an
             attribute of that resource.
+
+            Terraform used the selected providers to generate the following execution
+            plan. Resource actions are indicated with the following symbols:
+              + create
+
+            Terraform planned the following actions, but then encountered a problem:
+
+              # random_id.foo[0] will be created
+              + resource "random_id" "foo" {
+                  + b64_std     = (known after apply)
+                  + b64_url     = (known after apply)
+                  + byte_length = 8
+                  + dec         = (known after apply)
+                  + hex         = (known after apply)
+                  + id          = (known after apply)
+                  + keepers     = {
+                      + "seed" = "foo-plat-ue2-sandbox-blue"
+                    }
+                }
+
+            Plan: 1 to add, 0 to change, 0 to destroy.
+
+            # Error                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
             exit status 1
             ```
-            
+
                 
-            
-            
+
+
                 
             </details>
+
+
+
+
+
+
 
   teardown:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-failed-plan.yml
+++ b/.github/workflows/test-failed-plan.yml
@@ -94,9 +94,9 @@ jobs:
 
       - uses: nick-fields/assert-action@v2
         with:
+          comparison: contains
           actual: "${{ fromJSON(needs.test.outputs.summary) }}"
-          expected: |-
-
+          expected: |
             ## Plan Failed for `foobar-fail` in `plat-ue2-sandbox`
               
             <a href="https://cloudposse.com/"><img src="https://cloudposse.com/logo-300x69.svg" width="100px" align="right"/></a>
@@ -140,12 +140,6 @@ jobs:
 
                 
             </details>
-
-
-
-
-
-
 
   teardown:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-failed-plan.yml
+++ b/.github/workflows/test-failed-plan.yml
@@ -96,6 +96,7 @@ jobs:
         with:
           actual: "${{ fromJSON(needs.test.outputs.summary) }}"
           expected: |-
+
             ## Plan Failed for `foobar-fail` in `plat-ue2-sandbox`
               
             <a href="https://cloudposse.com/"><img src="https://cloudposse.com/logo-300x69.svg" width="100px" align="right"/></a>

--- a/.github/workflows/test-failed-plan.yml
+++ b/.github/workflows/test-failed-plan.yml
@@ -95,8 +95,8 @@ jobs:
       - uses: nick-fields/assert-action@v2
         with:
           comparison: contains
-          actual: "${{ fromJSON(needs.test.outputs.summary) }}"
-          expected: |
+          expected: "${{ fromJSON(needs.test.outputs.summary) }}"
+          actual: |
           
             ## Plan Failed for `foobar-fail` in `plat-ue2-sandbox`
               

--- a/.github/workflows/test-failed-plan.yml
+++ b/.github/workflows/test-failed-plan.yml
@@ -98,6 +98,7 @@ jobs:
           actual: |
             ${{ fromJSON(needs.test.outputs.summary) }}
           expected: |
+          
             ## Plan Failed for `foobar-fail` in `plat-ue2-sandbox`
               
             <a href="https://cloudposse.com/"><img src="https://cloudposse.com/logo-300x69.svg" width="100px" align="right"/></a>

--- a/.github/workflows/test-failed-plan.yml
+++ b/.github/workflows/test-failed-plan.yml
@@ -62,7 +62,7 @@ jobs:
           stack: "plat-ue2-sandbox"
           sha: ${{ github.sha }}
           atmos-config-path: ${{ runner.temp }}
-          atmos-version: 1.145.0
+          atmos-version: 1.160.0
           skip-checkout: true
 
     outputs:

--- a/.github/workflows/test-failed-plan.yml
+++ b/.github/workflows/test-failed-plan.yml
@@ -94,55 +94,57 @@ jobs:
 
       - uses: nick-fields/assert-action@v2
         with:
-          actual: "^${{ fromJSON(needs.test.outputs.summary) }}^"
+          actual: "${{ fromJSON(needs.test.outputs.summary) }}"
           expected: |-
             ## Plan Failed for `foobar-fail` in `plat-ue2-sandbox`
-
+              
             <a href="https://cloudposse.com/"><img src="https://cloudposse.com/logo-300x69.svg" width="100px" align="right"/></a>
-            
+              
             [![failed](https://shields.io/badge/PLAN-FAILED-ff0000?style=for-the-badge)](#user-content-result-plat-ue2-sandbox-foobar-fail)
-            
-            
-            
+
+
+
             <details><summary><a id="result-plat-ue2-sandbox-foobar-fail" />:warning: Error summary</summary>
-            
+
             <br/>      
             To reproduce this locally, run:<br/><br/>
-            
+
             ```shell
             atmos terraform plan foobar-fail -s plat-ue2-sandbox
             ```
-            
+
             ---
-            
+
             ```hcl
             Error: Invalid function argument
-            
+
               on main.tf line 17, in locals:
               17:   failure = var.enabled && var.enable_failure ? file("Failed because failure mode is enabled") : null
                 ├────────────────
                 │ while calling file(path)
-            
+
             Invalid value for "path" parameter: no file exists at "Failed because failure
             mode is enabled"; this function works only with files that are distributed as
             part of the configuration source code, so if this file will be created by a
             resource in this configuration you must instead obtain this result from an
             attribute of that resource.
+
+            # Error                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
             exit status 1
             ```
-            
+
                 
-            
-            
+
+
                 
             </details>
-            
-            
-            
-            
-            
-            
-            
+
+
+
+
+
+
 
   teardown:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-failed-plan.yml
+++ b/.github/workflows/test-failed-plan.yml
@@ -99,41 +99,44 @@ jobs:
             ## Plan Failed for `foobar-fail` in `plat-ue2-sandbox`
 
             <a href="https://cloudposse.com/"><img src="https://cloudposse.com/logo-300x69.svg" width="100px" align="right"/></a>
-            
+
             [![failed](https://shields.io/badge/PLAN-FAILED-ff0000?style=for-the-badge)](#user-content-result-plat-ue2-sandbox-foobar-fail)
-            
-            
-            
+
+
+
             <details><summary><a id="result-plat-ue2-sandbox-foobar-fail" />:warning: Error summary</summary>
-            
+
             <br/>      
             To reproduce this locally, run:<br/><br/>
-            
+
             ```shell
             atmos terraform plan foobar-fail -s plat-ue2-sandbox
             ```
-            
+
             ---
-            
+
             ```hcl
             Error: Invalid function argument
-            
+
               on main.tf line 17, in locals:
               17:   failure = var.enabled && var.enable_failure ? file("Failed because failure mode is enabled") : null
                 ├────────────────
                 │ while calling file(path)
-            
+
             Invalid value for "path" parameter: no file exists at "Failed because failure
             mode is enabled"; this function works only with files that are distributed as
             part of the configuration source code, so if this file will be created by a
             resource in this configuration you must instead obtain this result from an
             attribute of that resource.
+
+            # Error                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
             exit status 1
             ```
-            
+
                 
-            
-            
+
+
                 
             </details>
 

--- a/.github/workflows/test-failed-plan.yml
+++ b/.github/workflows/test-failed-plan.yml
@@ -92,6 +92,11 @@ jobs:
           actual: "${{ steps.metadata.outputs.dir_exists }}"
           expected: "1"
 
+      - run: |
+          echo <<<EOF
+          ${{ needs.test.outputs.summary }}
+          EOF;
+
       - uses: nick-fields/assert-action@v2
         with:
           actual: "${{ fromJSON(needs.test.outputs.summary) }}"

--- a/.github/workflows/test-failed-plan.yml
+++ b/.github/workflows/test-failed-plan.yml
@@ -90,12 +90,13 @@ jobs:
       - uses: nick-fields/assert-action@v2
         with:
           actual: "${{ steps.metadata.outputs.dir_exists }}"
-          expected: "1"
+          expected: "1"          
 
       - uses: nick-fields/assert-action@v2
         with:
           actual: "${{ fromJSON(needs.test.outputs.summary) }}"
-          expected: |
+          expected: |-
+            
             ## Plan Failed for `foobar-fail` in `plat-ue2-sandbox`
 
             <a href="https://cloudposse.com/"><img src="https://cloudposse.com/logo-300x69.svg" width="100px" align="right"/></a>

--- a/.github/workflows/test-failed-plan.yml
+++ b/.github/workflows/test-failed-plan.yml
@@ -96,7 +96,7 @@ jobs:
         with:
           actual: "${{ fromJSON(needs.test.outputs.summary) }}"
           expected: |-
-            
+
             ## Plan Failed for `foobar-fail` in `plat-ue2-sandbox`
 
             <a href="https://cloudposse.com/"><img src="https://cloudposse.com/logo-300x69.svg" width="100px" align="right"/></a>
@@ -137,6 +137,13 @@ jobs:
             
                 
             </details>
+            
+            
+            
+            
+            
+            
+            
 
   teardown:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-failed-plan.yml
+++ b/.github/workflows/test-failed-plan.yml
@@ -92,16 +92,10 @@ jobs:
           actual: "${{ steps.metadata.outputs.dir_exists }}"
           expected: "1"
 
-      # - run: |
-      #     echo <<<EOF
-      #       ${{ needs.test.outputs.summary }}
-      #     EOF;
-
       - uses: nick-fields/assert-action@v2
         with:
           actual: "${{ fromJSON(needs.test.outputs.summary) }}"
-          expected: |
-
+          expected: |-
             ## Plan Failed for `foobar-fail` in `plat-ue2-sandbox`
 
             <a href="https://cloudposse.com/"><img src="https://cloudposse.com/logo-300x69.svg" width="100px" align="right"/></a>

--- a/.github/workflows/test-failed-plan.yml
+++ b/.github/workflows/test-failed-plan.yml
@@ -97,6 +97,7 @@ jobs:
           comparison: contains
           actual: "${{ fromJSON(needs.test.outputs.summary) }}"
           expected: |
+          
             ## Plan Failed for `foobar-fail` in `plat-ue2-sandbox`
               
             <a href="https://cloudposse.com/"><img src="https://cloudposse.com/logo-300x69.svg" width="100px" align="right"/></a>

--- a/.github/workflows/test-failed-plan.yml
+++ b/.github/workflows/test-failed-plan.yml
@@ -99,10 +99,6 @@ jobs:
             ${{ fromJSON(needs.test.outputs.summary) }}
           expected: |-
             ## Plan Failed for `foobar-fail` in `plat-ue2-sandbox`
-              
-            <a href="https://cloudposse.com/"><img src="https://cloudposse.com/logo-300x69.svg" width="100px" align="right"/></a>
-              
-            [![failed](https://shields.io/badge/PLAN-FAILED-ff0000?style=for-the-badge)](#user-content-result-plat-ue2-sandbox-foobar-fail)
 
   teardown:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-failed-plan.yml
+++ b/.github/workflows/test-failed-plan.yml
@@ -62,7 +62,6 @@ jobs:
           stack: "plat-ue2-sandbox"
           sha: ${{ github.sha }}
           atmos-config-path: ${{ runner.temp }}
-          atmos-version: 1.99.0
           skip-checkout: true
 
     outputs:

--- a/.github/workflows/test-failed-plan.yml
+++ b/.github/workflows/test-failed-plan.yml
@@ -96,7 +96,6 @@ jobs:
         with:
           actual: "${{ fromJSON(needs.test.outputs.summary) }}"
           expected: |-
-
             ## Plan Failed for `foobar-fail` in `plat-ue2-sandbox`
 
             <a href="https://cloudposse.com/"><img src="https://cloudposse.com/logo-300x69.svg" width="100px" align="right"/></a>

--- a/.github/workflows/test-failed-plan.yml
+++ b/.github/workflows/test-failed-plan.yml
@@ -99,73 +99,43 @@ jobs:
             ## Plan Failed for `foobar-fail` in `plat-ue2-sandbox`
 
             <a href="https://cloudposse.com/"><img src="https://cloudposse.com/logo-300x69.svg" width="100px" align="right"/></a>
-
+            
             [![failed](https://shields.io/badge/PLAN-FAILED-ff0000?style=for-the-badge)](#user-content-result-plat-ue2-sandbox-foobar-fail)
-
-
-
+            
+            
+            
             <details><summary><a id="result-plat-ue2-sandbox-foobar-fail" />:warning: Error summary</summary>
-
+            
             <br/>      
             To reproduce this locally, run:<br/><br/>
-
+            
             ```shell
             atmos terraform plan foobar-fail -s plat-ue2-sandbox
             ```
-
+            
             ---
-
+            
             ```hcl
             Error: Invalid function argument
-
+            
               on main.tf line 17, in locals:
               17:   failure = var.enabled && var.enable_failure ? file("Failed because failure mode is enabled") : null
                 ├────────────────
                 │ while calling file(path)
-
+            
             Invalid value for "path" parameter: no file exists at "Failed because failure
             mode is enabled"; this function works only with files that are distributed as
             part of the configuration source code, so if this file will be created by a
             resource in this configuration you must instead obtain this result from an
             attribute of that resource.
-
-            Terraform used the selected providers to generate the following execution
-            plan. Resource actions are indicated with the following symbols:
-              + create
-
-            Terraform planned the following actions, but then encountered a problem:
-
-              # random_id.foo[0] will be created
-              + resource "random_id" "foo" {
-                  + b64_std     = (known after apply)
-                  + b64_url     = (known after apply)
-                  + byte_length = 8
-                  + dec         = (known after apply)
-                  + hex         = (known after apply)
-                  + id          = (known after apply)
-                  + keepers     = {
-                      + "seed" = "foo-plat-ue2-sandbox-blue"
-                    }
-                }
-
-            Plan: 1 to add, 0 to change, 0 to destroy.
-
-            # Error                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
             exit status 1
             ```
-
+            
                 
-
-
+            
+            
                 
             </details>
-
-
-
-
-
-
 
   teardown:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-failed-plan.yml
+++ b/.github/workflows/test-failed-plan.yml
@@ -92,15 +92,16 @@ jobs:
           actual: "${{ steps.metadata.outputs.dir_exists }}"
           expected: "1"
 
-      - run: |
-          echo <<<EOF
-          ${{ needs.test.outputs.summary }}
-          EOF;
+      # - run: |
+      #     echo <<<EOF
+      #       ${{ needs.test.outputs.summary }}
+      #     EOF;
 
       - uses: nick-fields/assert-action@v2
         with:
           actual: "${{ fromJSON(needs.test.outputs.summary) }}"
           expected: |
+
             ## Plan Failed for `foobar-fail` in `plat-ue2-sandbox`
 
             <a href="https://cloudposse.com/"><img src="https://cloudposse.com/logo-300x69.svg" width="100px" align="right"/></a>

--- a/.github/workflows/test-failed-plan.yml
+++ b/.github/workflows/test-failed-plan.yml
@@ -114,32 +114,6 @@ jobs:
             atmos terraform plan foobar-fail -s plat-ue2-sandbox
             ```
 
-            ---
-
-            ```hcl
-            Error: Invalid function argument
-
-              on main.tf line 17, in locals:
-              17:   failure = var.enabled && var.enable_failure ? file("Failed because failure mode is enabled") : null
-                ├────────────────
-                │ while calling file(path)
-
-            Invalid value for "path" parameter: no file exists at "Failed because failure
-            mode is enabled"; this function works only with files that are distributed as
-            part of the configuration source code, so if this file will be created by a
-            resource in this configuration you must instead obtain this result from an
-            attribute of that resource.
-
-            # Error                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
-            exit status 1
-            ```
-
-                
-
-
-                
-            </details>
 
   teardown:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-failed-plan.yml
+++ b/.github/workflows/test-failed-plan.yml
@@ -98,6 +98,48 @@ jobs:
           actual: "${{ fromJSON(needs.test.outputs.summary) }}"
           expected: |-
             ## Plan Failed for `foobar-fail` in `plat-ue2-sandbox`
+              
+            <a href="https://cloudposse.com/"><img src="https://cloudposse.com/logo-300x69.svg" width="100px" align="right"/></a>
+              
+            [![failed](https://shields.io/badge/PLAN-FAILED-ff0000?style=for-the-badge)](#user-content-result-plat-ue2-sandbox-foobar-fail)
+
+
+
+            <details><summary><a id="result-plat-ue2-sandbox-foobar-fail" />:warning: Error summary</summary>
+
+            <br/>      
+            To reproduce this locally, run:<br/><br/>
+
+            ```shell
+            atmos terraform plan foobar-fail -s plat-ue2-sandbox
+            ```
+
+            ---
+
+            ```hcl
+            Error: Invalid function argument
+
+              on main.tf line 17, in locals:
+              17:   failure = var.enabled && var.enable_failure ? file("Failed because failure mode is enabled") : null
+                ├────────────────
+                │ while calling file(path)
+
+            Invalid value for "path" parameter: no file exists at "Failed because failure
+            mode is enabled"; this function works only with files that are distributed as
+            part of the configuration source code, so if this file will be created by a
+            resource in this configuration you must instead obtain this result from an
+            attribute of that resource.
+
+            # Error                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+            exit status 1
+            ```
+
+                
+
+
+                
+            </details>
 
   teardown:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-failed-plan.yml
+++ b/.github/workflows/test-failed-plan.yml
@@ -100,7 +100,7 @@ jobs:
           expected: |
           
             ## Plan Failed for `foobar-fail` in `plat-ue2-sandbox`
-              
+            
             <a href="https://cloudposse.com/"><img src="https://cloudposse.com/logo-300x69.svg" width="100px" align="right"/></a>
 
   teardown:

--- a/.github/workflows/test-infra-cost.yml
+++ b/.github/workflows/test-infra-cost.yml
@@ -64,7 +64,6 @@ jobs:
           infracost-api-key: ${{ secrets.INFRACOST_API_KEY }}
           debug: true
           atmos-config-path: ${{ runner.temp }}
-          atmos-version: 1.99.0
           skip-checkout: true
 
     outputs:

--- a/.github/workflows/test-no-changes-drift-more.yml
+++ b/.github/workflows/test-no-changes-drift-more.yml
@@ -62,7 +62,6 @@ jobs:
           sha: ${{ github.sha }}
           drift-detection-mode-enabled: true
           atmos-config-path: ${{ runner.temp }}
-          atmos-version: 1.99.0
           skip-checkout: true
 
     outputs:

--- a/.github/workflows/test-no-changes.yml
+++ b/.github/workflows/test-no-changes.yml
@@ -61,7 +61,6 @@ jobs:
           stack: "plat-ue2-sandbox"
           sha: ${{ github.sha }}
           atmos-config-path: ${{ runner.temp }}
-          atmos-version: 1.99.0
           skip-checkout: true
 
     outputs:

--- a/.github/workflows/test-settings-action-disabled-drift.yml
+++ b/.github/workflows/test-settings-action-disabled-drift.yml
@@ -62,7 +62,6 @@ jobs:
           sha: ${{ github.sha }}
           drift-detection-mode-enabled: true
           atmos-config-path: ${{ runner.temp }}
-          atmos-version: 1.99.0
           skip-checkout: true
 
     outputs:

--- a/.github/workflows/test-settings-action-disabled.yml
+++ b/.github/workflows/test-settings-action-disabled.yml
@@ -61,7 +61,6 @@ jobs:
           stack: "plat-ue2-sandbox"
           sha: ${{ github.sha }}
           atmos-config-path: ${{ runner.temp }}
-          atmos-version: 1.99.0
           skip-checkout: true
 
     outputs:

--- a/README.yaml
+++ b/README.yaml
@@ -56,7 +56,8 @@ usage: |-
   ### Config
 
   > [!IMPORTANT]
-  > **Please note!** This GitHub Action only works with `atmos >= 1.99.0`.
+  > **Please note!** This GitHub Action only works with `atmos >= v1.158.0`
+  > If you are using `atmos >= 1.99.0, < 1.158.0` please use `v4` version of this action.
   > If you are using `atmos >= 1.63.0, < 1.99.0` please use `v2` or `v3` version of this action.  
   > If you are using `atmos < 1.63.0` please use `v1` version of this action.
 
@@ -203,9 +204,15 @@ usage: |-
               component: "foobar"
               stack: "plat-ue2-sandbox"
               atmos-config-path: ./rootfs/usr/local/etc/atmos/
-              atmos-version: 1.81.0
+              atmos-version: 1.158.0
   ```
 
+  ### Migrating from `v4` to `v5`
+  
+  The notable changes in `v5` are:
+  - `v5` works only with `atmos >= 1.158.0`
+  - `v5` supports atnos `templates` and `functions`
+  
   ### Migrating from `v3` to `v4`
   
   The notable changes in `v4` are:

--- a/action.yml
+++ b/action.yml
@@ -98,6 +98,7 @@ runs:
         # Here we do not process-templates because that requires terraform. Which we install after fetching the version
         # processing templates here can cause an issue where cached terraform versions conflict with the version we want to install
         process-templates: 'false'
+        process-functions: 'false'
         settings: |
           - component: ${{ inputs.component }}
             stack: ${{ inputs.stack }}

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
   atmos-version:
     description: The version of atmos to install
     required: false
-    default: ">= 1.99.0"
+    default: ">= 1.158.0"
   atmos-config-path:
     description: The path to the atmos.yaml file
     required: true


### PR DESCRIPTION
## Breaking Change!
* Requires `atmos >= 1.158.0`. Will fail on older version

## what
* Disable process functions for `cloudposse/github-action-atmos-get-setting`

## why
* `process-functions` requires terraform. Which we install after fetching the version
* `process-functions` can cause an issue where cached terraform versions conflict with the version we want to install
* `atmos < 1.158.0` not not support flag `--process-functions`



