### PR TITLE
fix: JSON Planfile Conversion 

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,10 @@ Which would produce the same behavior as in `v1`, doing this:
 
 
 
+
+
+
+
 <!-- markdownlint-disable -->
 
 ## Inputs

--- a/action.yml
+++ b/action.yml
@@ -409,6 +409,13 @@ runs:
 
         rm -f ${TERRAFORM_OUTPUT_FILE}
 
+    - name: Convert PLANFILE to JSON
+      if: ${{ steps.atmos-plan.outputs.changes == 'true' }}
+      shell: bash
+      working-directory: ./${{ steps.vars.outputs.component_path }}
+      run: |
+        ${{ fromJson(steps.atmos-settings.outputs.settings).command }} show -json "${{ steps.vars.outputs.plan_file }}" > "${{ steps.vars.outputs.plan_file }}.json"
+
     - name: Configure State AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       if: ${{ ( fromJson(steps.atmos-settings.outputs.settings).plan-repository-type == 's3' ||
@@ -468,18 +475,6 @@ runs:
       uses: infracost/actions/setup@v3
       with:
         api-key: ${{ inputs.infracost-api-key }}
-
-    - name: Convert PLANFILE to JSON
-      if: ${{ steps.atmos-plan.outputs.changes == 'true' }}
-      shell: bash
-      working-directory: ./${{ steps.vars.outputs.component_path }}
-      run: |
-        # debug
-        echo "debug"
-        ls -al
-        pwd
-        cat "${{ steps.vars.outputs.plan_file }}"
-        ${{ fromJson(steps.atmos-settings.outputs.settings).command }} show -json "${{ steps.vars.outputs.plan_file }}" > "${{ steps.vars.outputs.plan_file }}.json"
 
     - name: Set Plan Results
       id: results

--- a/action.yml
+++ b/action.yml
@@ -298,6 +298,8 @@ runs:
         path: |
           ./${{ steps.vars.outputs.component_path }}/.terraform
         key: ${{ steps.vars.outputs.cache-key }}
+        restore-keys: |
+          ${{ steps.vars.outputs.cache-key }}
 
     - name: Atmos Terraform Plan
       if: ${{ fromJson(steps.atmos-settings.outputs.settings).github-actions-enabled || fromJson(steps.atmos-settings.outputs.settings).atmos-pro-enabled }}

--- a/action.yml
+++ b/action.yml
@@ -473,7 +473,7 @@ runs:
     - name: Convert PLANFILE to JSON
       if: ${{ steps.atmos-plan.outputs.changes == 'true' }}
       shell: bash
-      working-directory: ./${{ steps.vars.outputs.component_path }}
+      working-directory: ${{ steps.vars.outputs.component_path }}
       run: |
         ${{ fromJson(steps.atmos-settings.outputs.settings).command }} show -json "${{ steps.vars.outputs.plan_file }}" > "${{ steps.vars.outputs.plan_file }}.json"
 

--- a/action.yml
+++ b/action.yml
@@ -267,7 +267,7 @@ runs:
         COMPONENT_PATH=${{ fromJson(steps.atmos-settings.outputs.settings).component-path }}
         COMPONENT_NAME=$(echo "${{ inputs.component }}" | sed 's#/#_#g')
         COMPONENT_SLUG="$STACK_NAME-$COMPONENT_NAME"
-        COMPONENT_CACHE_KEY="$(basename "${{ fromJson(steps.atmos-settings.outputs.settings).component-path }}")"
+        COMPONENT_CACHE_KEY=$(basename "${{ fromJson(steps.atmos-settings.outputs.settings).component-path }}")
         PLAN_FILE="$( realpath ${COMPONENT_PATH})/$COMPONENT_SLUG-${{ inputs.sha }}.planfile"
         PLAN_FILE_JSON="$( realpath ${COMPONENT_PATH})/$COMPONENT_SLUG-${{ inputs.sha }}.planfile.json"
         LOCK_FILE="$( realpath ${COMPONENT_PATH})/.terraform.lock.hcl"
@@ -292,13 +292,11 @@ runs:
     - name: Cache .terraform
       id: cache
       uses: actions/cache@v4
-      if: ${{ (fromJson(steps.atmos-settings.outputs.settings).github-actions-enabled || fromJson(steps.atmos-settings.outputs.settings).atmos-pro-enabled)}}
+      if: ${{ fromJson(steps.atmos-settings.outputs.settings).github-actions-enabled || fromJson(steps.atmos-settings.outputs.settings).atmos-pro-enabled }}
       with:
         path: |
           ./${{ steps.vars.outputs.component_path }}/.terraform
         key: ${{ steps.vars.outputs.cache-key }}
-        restore-keys: |
-          ${{ steps.vars.outputs.cache-key }}
 
     - name: Atmos Terraform Plan
       if: ${{ fromJson(steps.atmos-settings.outputs.settings).github-actions-enabled || fromJson(steps.atmos-settings.outputs.settings).atmos-pro-enabled }}

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,10 @@ inputs:
     description: "Indicate whether this action is used in drift detection workflow."
     required: true
     default: 'false'
+  cache-enabled:
+    description: "Enable caching"
+    required: false
+    default: 'true'
   atmos-version:
     description: The version of atmos to install
     required: false
@@ -292,7 +296,7 @@ runs:
     - name: Cache .terraform
       id: cache
       uses: actions/cache@v4
-      if: ${{ fromJson(steps.atmos-settings.outputs.settings).github-actions-enabled || fromJson(steps.atmos-settings.outputs.settings).atmos-pro-enabled }}
+      if: ${{ (fromJson(steps.atmos-settings.outputs.settings).github-actions-enabled || fromJson(steps.atmos-settings.outputs.settings).atmos-pro-enabled) && inputs.cache-enabled == 'true' }}
       with:
         path: |
           ./${{ steps.vars.outputs.component_path }}/.terraform

--- a/action.yml
+++ b/action.yml
@@ -409,12 +409,10 @@ runs:
 
         rm -f ${TERRAFORM_OUTPUT_FILE}
 
-    - name: Convert PLANFILE to JSON
-      if: ${{ steps.atmos-plan.outputs.changes == 'true' }}
-      shell: bash
-      working-directory: ./${{ steps.vars.outputs.component_path }}
-      run: |
-        ${{ fromJson(steps.atmos-settings.outputs.settings).command }} show -json "${{ steps.vars.outputs.plan_file }}" > "${{ steps.vars.outputs.plan_file }}.json"
+        # Convert planfile to JSON if Infracost is enabled
+        if [[ "${{ fromJson(steps.atmos-settings.outputs.settings).enable-infracost }}" == "true" && "${TERRAFORM_RESULT}" == "0" ]]; then
+          ${{ fromJson(steps.atmos-settings.outputs.settings).command }} show -json "${{ steps.vars.outputs.plan_file }}" > "${{ steps.vars.outputs.plan_file }}.json"
+        fi
 
     - name: Configure State AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4

--- a/action.yml
+++ b/action.yml
@@ -410,6 +410,7 @@ runs:
         rm -f ${TERRAFORM_OUTPUT_FILE}
 
         # Convert planfile to JSON if Infracost is enabled
+        # Infracost requires a JSON representation of the plan to analyze cost changes
         if [[ "${{ fromJson(steps.atmos-settings.outputs.settings).enable-infracost }}" == "true" && "${TERRAFORM_RESULT}" == "0" ]]; then
           ${{ fromJson(steps.atmos-settings.outputs.settings).command }} show -json "${{ steps.vars.outputs.plan_file }}" > "${{ steps.vars.outputs.plan_file }}.json"
         fi

--- a/action.yml
+++ b/action.yml
@@ -473,8 +473,11 @@ runs:
     - name: Convert PLANFILE to JSON
       if: ${{ steps.atmos-plan.outputs.changes == 'true' }}
       shell: bash
-      working-directory: ${{ steps.vars.outputs.component_path }}
+      working-directory: ./${{ steps.vars.outputs.component_path }}
       run: |
+        # Initialize terraform to ensure providers are available
+        ${{ fromJson(steps.atmos-settings.outputs.settings).command }} init -input=false -no-color
+        # Now show the plan in JSON format
         ${{ fromJson(steps.atmos-settings.outputs.settings).command }} show -json "${{ steps.vars.outputs.plan_file }}" > "${{ steps.vars.outputs.plan_file }}.json"
 
     - name: Set Plan Results

--- a/action.yml
+++ b/action.yml
@@ -267,8 +267,7 @@ runs:
         COMPONENT_PATH=${{ fromJson(steps.atmos-settings.outputs.settings).component-path }}
         COMPONENT_NAME=$(echo "${{ inputs.component }}" | sed 's#/#_#g')
         COMPONENT_SLUG="$STACK_NAME-$COMPONENT_NAME"
-        COMMAND=${{ fromJson(steps.atmos-settings.outputs.settings).command }}
-        COMPONENT_CACHE_KEY="$(basename "${{ fromJson(steps.atmos-settings.outputs.settings).component-path }}")-${COMMAND}"
+        COMPONENT_CACHE_KEY="$(basename "${{ fromJson(steps.atmos-settings.outputs.settings).component-path }}")"
         PLAN_FILE="$( realpath ${COMPONENT_PATH})/$COMPONENT_SLUG-${{ inputs.sha }}.planfile"
         PLAN_FILE_JSON="$( realpath ${COMPONENT_PATH})/$COMPONENT_SLUG-${{ inputs.sha }}.planfile.json"
         LOCK_FILE="$( realpath ${COMPONENT_PATH})/.terraform.lock.hcl"
@@ -475,9 +474,11 @@ runs:
       shell: bash
       working-directory: ./${{ steps.vars.outputs.component_path }}
       run: |
-        # Initialize terraform to ensure providers are available
-        ${{ fromJson(steps.atmos-settings.outputs.settings).command }} init -input=false -no-color
-        # Now show the plan in JSON format
+        # debug
+        echo "debug"
+        ls -al
+        pwd
+        cat "${{ steps.vars.outputs.plan_file }}"
         ${{ fromJson(steps.atmos-settings.outputs.settings).command }} show -json "${{ steps.vars.outputs.plan_file }}" > "${{ steps.vars.outputs.plan_file }}.json"
 
     - name: Set Plan Results

--- a/action.yml
+++ b/action.yml
@@ -19,10 +19,6 @@ inputs:
     description: "Indicate whether this action is used in drift detection workflow."
     required: true
     default: 'false'
-  cache-enabled:
-    description: "Enable caching"
-    required: false
-    default: 'true'
   atmos-version:
     description: The version of atmos to install
     required: false
@@ -271,7 +267,8 @@ runs:
         COMPONENT_PATH=${{ fromJson(steps.atmos-settings.outputs.settings).component-path }}
         COMPONENT_NAME=$(echo "${{ inputs.component }}" | sed 's#/#_#g')
         COMPONENT_SLUG="$STACK_NAME-$COMPONENT_NAME"
-        COMPONENT_CACHE_KEY=$(basename "${{ fromJson(steps.atmos-settings.outputs.settings).component-path }}")
+        COMMAND=${{ fromJson(steps.atmos-settings.outputs.settings).command }}
+        COMPONENT_CACHE_KEY="$(basename "${{ fromJson(steps.atmos-settings.outputs.settings).component-path }}")-${COMMAND}"
         PLAN_FILE="$( realpath ${COMPONENT_PATH})/$COMPONENT_SLUG-${{ inputs.sha }}.planfile"
         PLAN_FILE_JSON="$( realpath ${COMPONENT_PATH})/$COMPONENT_SLUG-${{ inputs.sha }}.planfile.json"
         LOCK_FILE="$( realpath ${COMPONENT_PATH})/.terraform.lock.hcl"
@@ -296,7 +293,7 @@ runs:
     - name: Cache .terraform
       id: cache
       uses: actions/cache@v4
-      if: ${{ (fromJson(steps.atmos-settings.outputs.settings).github-actions-enabled || fromJson(steps.atmos-settings.outputs.settings).atmos-pro-enabled) && inputs.cache-enabled == 'true' }}
+      if: ${{ (fromJson(steps.atmos-settings.outputs.settings).github-actions-enabled || fromJson(steps.atmos-settings.outputs.settings).atmos-pro-enabled)}}
       with:
         path: |
           ./${{ steps.vars.outputs.component_path }}/.terraform

--- a/action.yml
+++ b/action.yml
@@ -410,6 +410,7 @@ runs:
         # Convert planfile to JSON if Infracost is enabled
         # Infracost requires a JSON representation of the plan to analyze cost changes
         if [[ "${{ fromJson(steps.atmos-settings.outputs.settings).enable-infracost }}" == "true" && "${TERRAFORM_RESULT}" == "0" ]]; then
+          cd "${{ steps.vars.outputs.component_path }}"
           ${{ fromJson(steps.atmos-settings.outputs.settings).command }} show -json "${{ steps.vars.outputs.plan_file }}" > "${{ steps.vars.outputs.plan_file }}.json"
         fi
 

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -5,7 +5,7 @@
 | Name | Description | Default | Required |
 |------|-------------|---------|----------|
 | atmos-config-path | The path to the atmos.yaml file | N/A | true |
-| atmos-version | The version of atmos to install | >= 1.99.0 | false |
+| atmos-version | The version of atmos to install | >= 1.158.0 | false |
 | branding-logo-image | Branding logo image url | https://cloudposse.com/logo-300x69.svg | false |
 | branding-logo-url | Branding logo url | https://cloudposse.com/ | false |
 | component | The name of the component to plan. | N/A | true |


### PR DESCRIPTION
## what
- Moved JSON conversion into the plan step

## why
- Previously we were running the JSON conversion after we assumed another AWS role

## references
- This ultimately fixed an errors like this. The cache mentioned is entirely a red herring
```bash
Run tofu show -json "/home/runner/_work/infra-test/infra-test/components/terraform/s3-bucket/plat-ue2-sandbox-test-atmos-pro-3-xyz.planfile" > "/home/runner/_work/infra-test/infra-test/components/terraform/s3-bucket/plat-ue2-sandbox-test-atmos-pro-3-xyz.planfile.json"
╷
│ Error: missing or corrupted provider plugins:
│   - registry.opentofu.org/hashicorp/time: there is no package for registry.opentofu.org/hashicorp/time 0.13.1 cached in .terraform/providers
```