### PR TITLE
Fix working directory path syntax in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -566,7 +566,7 @@ runs:
     - name: Publish Summary or Generate GitHub Issue Description for Drift Detection
       id: summary
       shell: bash
-      working-directory: ./${{ steps.vars.outputs.component_path }}
+      working-directory: ${{ steps.vars.outputs.component_path }}
       run: |
         if [[ "${{ inputs.drift-detection-mode-enabled }}" == "true" ]]; then
           STEP_SUMMARY_FILE="${{ steps.vars.outputs.issue_file }}"


### PR DESCRIPTION
## what
* Fix plan error


## why
* Planning had raise the error

```
Error: An error occurred trying to start process '/usr/bin/bash' with working directory '/home/runner/work/github-action-atmos-terraform-apply/github-action-atmos-terraform-apply/.//home/runner/work/github-action-atmos-terraform-apply/github-action-atmos-terraform-apply/tests/opentofu/components/terraform/foobar'. No such file or directory
```