### PR TITLE
feat: Add `has-changes` output to expose plan change detection

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -85,6 +85,9 @@ outputs:
   plan_json:
     description: "Path to the terraform plan in JSON format"
     value: "${{ steps.results.outputs.plan_file_json }}"
+  has-changes:
+    description: "Whether the plan has changes. Value is string 'true' or 'false'"
+    value: "${{ steps.atmos-plan.outputs.changes }}"
 
 runs:
   using: "composite"


### PR DESCRIPTION
## Summary

- Adds a new `has-changes` output that exposes whether the Terraform plan contains infrastructure changes
- The output is a string value of `"true"` or `"false"`

## Motivation

Currently, consumers who want to conditionally run steps based on whether the plan has changes must parse the `summary` output. The action already computes this internally (used for Infracost integration), but doesn't expose it.

This change simply exposes the existing `steps.atmos-plan.outputs.changes` value as a proper action output.

## Usage

```yaml
- uses: cloudposse/github-action-atmos-terraform-plan@v4
  id: plan
  with:
    component: mycomponent
    stack: dev

- if: steps.plan.outputs.has-changes == 'true'
  run: echo "Infrastructure changes detected"
```

## Test plan

- [ ] Verify output is `"true"` when plan has changes
- [ ] Verify output is `"false"` when plan has no changes