### PR TITLE
fix: fix tests

### DIFF
--- a/.github/workflows/test-failed-plan-drift.yml
+++ b/.github/workflows/test-failed-plan-drift.yml
@@ -154,8 +154,8 @@ jobs:
 
             <details><summary><a id="result-plat-ue2-sandbox-foobar-fail" />:warning: Error summary</summary>
 
-            <br/>
-            To reproduce this locally, run:<br/><br/>
+            <br/>      
+            To reproduce this locally, run:<br/><br/>      
 
             ```shell
             atmos terraform plan foobar-fail -s plat-ue2-sandbox

--- a/.github/workflows/test-failed-plan-drift.yml
+++ b/.github/workflows/test-failed-plan-drift.yml
@@ -148,9 +148,15 @@ jobs:
           expected: |
             ## Drift Detection Failed for `foobar-fail` in `plat-ue2-sandbox`!
 
+
+
             <a href="https://cloudposse.com/"><img src="https://cloudposse.com/logo-300x69.svg" width="100px" align="right"/></a>
 
+
             [![failed](https://shields.io/badge/PLAN-FAILED-ff0000?style=for-the-badge)](#user-content-result-plat-ue2-sandbox-foobar-fail)
+
+
+
 
             <details><summary><a id="result-plat-ue2-sandbox-foobar-fail" />:warning: Error summary</summary>
 

--- a/.github/workflows/test-failed-plan-drift.yml
+++ b/.github/workflows/test-failed-plan-drift.yml
@@ -158,6 +158,7 @@ jobs:
 
 
 
+
             <details><summary><a id="result-plat-ue2-sandbox-foobar-fail" />:warning: Error summary</summary>
 
             <br/>      

--- a/.github/workflows/test-failed-plan-drift.yml
+++ b/.github/workflows/test-failed-plan-drift.yml
@@ -184,25 +184,6 @@ jobs:
             resource in this configuration you must instead obtain this result from an
             attribute of that resource.
 
-            # Error
-
-            **Error:** subcommand exited with code 1
-            ```
-
-            </details>
-
-            <details><summary>Metadata</summary>
-
-            ```json
-            {
-              "component": "foobar-fail",
-              "stack": "plat-ue2-sandbox",
-              "componentPath": "tests/terraform/components/terraform/foobar",
-              "commitSHA": "${{ github.sha }}"
-            }
-            ```
-            </details>
-
   teardown:
     runs-on: ubuntu-latest
     needs: [assert]

--- a/.github/workflows/test-failed-plan-drift.yml
+++ b/.github/workflows/test-failed-plan-drift.yml
@@ -155,7 +155,7 @@ jobs:
             <details><summary><a id="result-plat-ue2-sandbox-foobar-fail" />:warning: Error summary</summary>
 
             <br/>      
-            To reproduce this locally, run:<br/><br/>      
+            To reproduce this locally, run:<br/><br/>
 
             ```shell
             atmos terraform plan foobar-fail -s plat-ue2-sandbox

--- a/.github/workflows/test-failed-plan-drift.yml
+++ b/.github/workflows/test-failed-plan-drift.yml
@@ -51,9 +51,9 @@ jobs:
           for file in ./tests/terraform/stacks/catalog/*.yaml; do
           if [ -f "$file" ]; then
             sed -i -e "s#__INFRACOST_ENABLED__#false#g" "$file"
-            sed -i -e "s#__STORAGE_REGION__#${{ env.AWS_REGION }}#g" "$file"          
+            sed -i -e "s#__STORAGE_REGION__#${{ env.AWS_REGION }}#g" "$file"
             sed -i -e "s#__STORAGE_BUCKET__#${{ secrets.TERRAFORM_STATE_BUCKET }}#g" "$file"
-            sed -i -e "s#__STORAGE_TABLE__#${{ secrets.TERRAFORM_STATE_TABLE }}#g" "$file"          
+            sed -i -e "s#__STORAGE_TABLE__#${{ secrets.TERRAFORM_STATE_TABLE }}#g" "$file"
             sed -i -e "s#__STORAGE_TABLE__#${{ secrets.TERRAFORM_STATE_TABLE }}#g" "$file"
             sed -i -e "s#__STORAGE_ROLE__#${{ secrets.TERRAFORM_STATE_ROLE }}#g" "$file"
             sed -i -e "s#__PLAN_ROLE__#${{ secrets.TERRAFORM_PLAN_ROLE }}#g" "$file"
@@ -97,7 +97,7 @@ jobs:
         id: metadata
         run: |
           set +e
-          
+
           test -d ./metadata
           DIR_EXISTS=$?
           echo "dir_exists=${DIR_EXISTS}" >> $GITHUB_OUTPUT
@@ -109,10 +109,10 @@ jobs:
           test -f ./metadata/issue-description-plat-ue2-sandbox-foobar-fail.md
           FILE_EXISTS=$?
           echo "file_md_exists=${FILE_EXISTS}" >> $GITHUB_OUTPUT
-          
+
           echo "file_md=$(cat ./metadata/issue-description-plat-ue2-sandbox-foobar-fail.md | jq -Rs .)" >> $GITHUB_OUTPUT
-          
-          echo "file_json=$(cat ./metadata/plat-ue2-sandbox-foobar-fail.metadata.json | jq -Rs . )" >> $GITHUB_OUTPUT          
+
+          echo "file_json=$(cat ./metadata/plat-ue2-sandbox-foobar-fail.metadata.json | jq -Rs . )" >> $GITHUB_OUTPUT
 
       - uses: nick-fields/assert-action@v2
         with:
@@ -142,27 +142,19 @@ jobs:
 
       - uses: nick-fields/assert-action@v2
         with:
-          comparison: contains          
+          comparison: contains
           actual: |
             ${{ fromJSON(needs.test.outputs.summary) }}
           expected: |
-          
             ## Drift Detection Failed for `foobar-fail` in `plat-ue2-sandbox`!
-
-
 
             <a href="https://cloudposse.com/"><img src="https://cloudposse.com/logo-300x69.svg" width="100px" align="right"/></a>
 
-
             [![failed](https://shields.io/badge/PLAN-FAILED-ff0000?style=for-the-badge)](#user-content-result-plat-ue2-sandbox-foobar-fail)
-
-
-
-
 
             <details><summary><a id="result-plat-ue2-sandbox-foobar-fail" />:warning: Error summary</summary>
 
-            <br/>      
+            <br/>
             To reproduce this locally, run:<br/><br/>
 
             ```shell
@@ -190,17 +182,7 @@ jobs:
             **Error:** subcommand exited with code 1
             ```
 
-                
-
-
-                
             </details>
-
-
-                  
-
-
-
 
             <details><summary>Metadata</summary>
 

--- a/action.yml
+++ b/action.yml
@@ -85,6 +85,9 @@ outputs:
   plan_json:
     description: "Path to the terraform plan in JSON format"
     value: "${{ steps.results.outputs.plan_file_json }}"
+  has-changes:
+    description: "Whether the plan has changes. Value is string 'true' or 'false'"
+    value: "${{ steps.atmos-plan.outputs.changes }}"
 
 runs:
   using: "composite"


### PR DESCRIPTION
This pull request introduces a minor improvement to the GitHub Actions workflow and action metadata. The main changes involve cleaning up formatting in the workflow output and adding a new output to the action.

Action output enhancement:

* Added a new output `has-changes` to `action.yml`, which indicates whether the Terraform plan has changes, with the value being the string `'true'` or `'false'`.

Workflow formatting cleanup:

* Removed unnecessary blank lines in the `expected` and `actual` output sections of `.github/workflows/test-failed-plan-drift.yml` to improve output readability and consistency. [[1]](diffhunk://#diff-26183f3c281c05770533979b4399596bea1d98934866d78883c9ef6d557fd4beL149-L162) [[2]](diffhunk://#diff-26183f3c281c05770533979b4399596bea1d98934866d78883c9ef6d557fd4beL193-L204)
