### PR TITLE
Fix tests

### DIFF
--- a/.github/workflows/test-failed-plan-drift.yml
+++ b/.github/workflows/test-failed-plan-drift.yml
@@ -184,7 +184,6 @@ jobs:
             part of the configuration source code, so if this file will be created by a
             resource in this configuration you must instead obtain this result from an
             attribute of that resource.
-
             # Error
 
             **Error:** subcommand exited with code 1


### PR DESCRIPTION
This pull request introduces a minor improvement to the GitHub Actions workflow and action metadata. The main changes involve cleaning up formatting in the workflow output and adding a new output to the action.

Action output enhancement:

* Added a new output `has-changes` to `action.yml`, which indicates whether the Terraform plan has changes, with the value being the string `'true'` or `'false'`.

Workflow formatting cleanup:

* Removed unnecessary blank lines in the `expected` and `actual` output sections of `.github/workflows/test-failed-plan-drift.yml` to improve output readability and consistency. [[1]](diffhunk://#diff-26183f3c281c05770533979b4399596bea1d98934866d78883c9ef6d557fd4beL149-L162) [[2]](diffhunk://#diff-26183f3c281c05770533979b4399596bea1d98934866d78883c9ef6d557fd4beL193-L204)
