### PR TITLE
fix: Trigger release

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -89,6 +89,7 @@ outputs:
     description: "Whether the plan has changes. Value is string 'true' or 'false'"
     value: "${{ steps.atmos-plan.outputs.changes }}"
 
+
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
## what
* Added whitespace to trigger release 

## Why
* The latest release failed to be cut due test failure. Test fixed, so we need to issue a new release

## References
* https://github.com/cloudposse/github-action-atmos-terraform-plan/actions/runs/20932787693