### PR TITLE
fix: emit drift metadata block on plan parse errors

### DIFF
--- a/config/summary.yaml
+++ b/config/summary.yaml
@@ -205,4 +205,5 @@ terraform:
         <details><summary>Result</summary>
         {{wrapCode .CombinedOutput}}
         </details>
+        {{template "metadata" .}}
         {{- end }}


### PR DESCRIPTION
## what

- Add `{{template "metadata" .}}` to the `when_parse_error` branch of the drift-detection issue markdown in `config/summary.yaml`.
- This makes the hidden `json` metadata block present on **failure** issues that originate from a Terraform/atmos parse error, not just on successful/drift plans.

## why

- The companion `cloudposse/github-action-atmos-terraform-drift-detection` action only reconciles issues whose body contains a parseable ` ```json ` metadata block — it derives its matching key (`<stack>-<component>`) from that block and filters out any issue where `getMetadataFromIssueBody(body)` returns `null`.
- The main `terraform.plan.template` already appends `{{template "metadata" .}}` to its issue section, but the `when_parse_error` template (used when Terraform/atmos fails **before** producing a parseable plan — e.g. an OIDC/cloud-auth timeout or other early/network error) did not.
- As a result, "Failure Detected" issues created from early failures carried **no metadata block**, so the drift-detection action could never match them to a component and **never auto-closed them** once the component recovered. These issues accumulate open indefinitely.
- All template vars used by the `metadata` template (`component`, `stack`, `componentPath`, `commitSHA`) are already passed to `tfcmt` in both invocations, so they render correctly in the parse-error path. The change is a single line and does not affect the non-drift (PR comment) output.
- Verified in production over several days: pre-existing orphaned failure issues became closeable, and newly-created failure issues are now auto-closed by subsequent successful runs.

## references

- Reconcile filter that requires the metadata block: `cloudposse/github-action-atmos-terraform-drift-detection` — `src/action.js` (`mapOpenGitHubIssuesToComponents`) and `src/models/stacks_from_issues.js` (`getMetadataFromIssueBody`).
