### PR TITLE
chore: upgrade actions to Node 24 runtime (SHA-pinned)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -20,7 +20,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 

--- a/.github/workflows/test-atmos-pro-enabled.yml
+++ b/.github/workflows/test-atmos-pro-enabled.yml
@@ -34,7 +34,7 @@ jobs:
     continue-on-error: true
     needs: [setup]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 
@@ -85,7 +85,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: 'success'
           actual: "${{ needs.test.outputs.result }}"
@@ -99,12 +99,12 @@ jobs:
           DIR_EXISTS=$?
           echo "dir_exists=${DIR_EXISTS}" >> $GITHUB_OUTPUT
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           actual: "${{ steps.metadata.outputs.dir_exists }}"
           expected: "1"
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           actual: "${{ fromJSON(needs.test.outputs.summary) }}"
           expected: |

--- a/.github/workflows/test-changes-exists-drift.yml
+++ b/.github/workflows/test-changes-exists-drift.yml
@@ -31,7 +31,7 @@ jobs:
     continue-on-error: true
     needs: [setup]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 
@@ -81,13 +81,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: 'success'
           actual: "${{ needs.test.outputs.result }}"
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: metadata
           pattern: metadata-*
@@ -120,43 +120,43 @@ jobs:
           
           echo files_json_count=$(ls -lA ./metadata/*.json | wc -l) >> $GITHUB_OUTPUT
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           actual: "${{ steps.metadata.outputs.dir_exists }}"
           expected: "0"
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           actual: "${{ steps.metadata.outputs.file_exists }}"
           expected: "0"
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           actual: "${{ steps.metadata.outputs.file_md_exists }}"
           expected: "0"
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           actual: "${{ steps.metadata.outputs.file_summary_md_exists }}"
           expected: "0"
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           actual: "${{ fromJSON(needs.test.outputs.summary) }}"
           expected: "${{ fromJSON(steps.metadata.outputs.file_md) }}"
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           actual: "${{ steps.metadata.outputs.files_json_count }}"
           expected: "1"
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           actual: "${{ fromJSON(steps.metadata.outputs.file_json) }}"
           expected: |
             { "stack": "plat-ue2-sandbox", "component": "foobar/changes", "componentPath": "tests/opentofu/components/terraform/foobar", "drifted": true, "error": false }
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           actual: "${{ fromJSON(needs.test.outputs.summary) }}"
           expected: |

--- a/.github/workflows/test-changes-exists.yml
+++ b/.github/workflows/test-changes-exists.yml
@@ -32,7 +32,7 @@ jobs:
     continue-on-error: true
     needs: [setup]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: 'success'
           actual: "${{ needs.test.outputs.result }}"
@@ -97,12 +97,12 @@ jobs:
           DIR_EXISTS=$?
           echo "dir_exists=${DIR_EXISTS}" >> $GITHUB_OUTPUT
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           actual: "${{ steps.metadata.outputs.dir_exists }}"
           expected: "1"
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           actual: "${{ fromJSON(needs.test.outputs.summary) }}"
           expected: |

--- a/.github/workflows/test-failed-plan-drift.yml
+++ b/.github/workflows/test-failed-plan-drift.yml
@@ -31,7 +31,7 @@ jobs:
     continue-on-error: true
     needs: [setup]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 
@@ -81,13 +81,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: 'failure'
           actual: "${{ needs.test.outputs.result }}"
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: metadata
           pattern: metadata-*
@@ -114,33 +114,33 @@ jobs:
           
           echo "file_json=$(cat ./metadata/plat-ue2-sandbox-foobar-fail.metadata.json | jq -Rs . )" >> $GITHUB_OUTPUT          
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           actual: "${{ steps.metadata.outputs.dir_exists }}"
           expected: "0"
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           actual: "${{ steps.metadata.outputs.file_exists }}"
           expected: "0"
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           actual: "${{ steps.metadata.outputs.file_md_exists }}"
           expected: "0"
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           actual: "${{ fromJSON(needs.test.outputs.summary) }}"
           expected: "${{ fromJSON(steps.metadata.outputs.file_md) }}"
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           actual: "${{ fromJSON(steps.metadata.outputs.file_json) }}"
           expected: |
             { "stack": "plat-ue2-sandbox", "component": "foobar-fail", "componentPath": "tests/terraform/components/terraform/foobar", "drifted": false, "error": true }
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           comparison: contains          
           actual: |

--- a/.github/workflows/test-failed-plan.yml
+++ b/.github/workflows/test-failed-plan.yml
@@ -31,7 +31,7 @@ jobs:
     continue-on-error: true
     needs: [setup]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 
@@ -81,7 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: 'failure'
           actual: "${{ needs.test.outputs.result }}"
@@ -95,12 +95,12 @@ jobs:
           DIR_EXISTS=$?
           echo "dir_exists=${DIR_EXISTS}" >> $GITHUB_OUTPUT
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           actual: "${{ steps.metadata.outputs.dir_exists }}"
           expected: "1"          
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           comparison: contains
           actual: |

--- a/.github/workflows/test-infra-cost.yml
+++ b/.github/workflows/test-infra-cost.yml
@@ -31,7 +31,7 @@ jobs:
     continue-on-error: true
     needs: [setup]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: 'success'
           actual: "${{ needs.test.outputs.result }}"
@@ -96,13 +96,13 @@ jobs:
           DIR_EXISTS=$?
           echo "dir_exists=${DIR_EXISTS}" >> $GITHUB_OUTPUT
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           actual: "${{ steps.metadata.outputs.dir_exists }}"
           expected: "1"
 
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           actual: "${{ fromJSON(needs.test.outputs.summary) }}"
           expected: |

--- a/.github/workflows/test-no-changes-drift-more.yml
+++ b/.github/workflows/test-no-changes-drift-more.yml
@@ -31,7 +31,7 @@ jobs:
     continue-on-error: true
     needs: [setup]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: 'success'
           actual: "${{ needs.test.outputs.result }}"
@@ -91,7 +91,7 @@ jobs:
           time: '30s'
           
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: metadata
           pattern: metadata-*
@@ -117,28 +117,28 @@ jobs:
           echo "file_json=$(cat ./metadata/plat-ue2-sandbox-foobar.metadata.json | jq -Rs . )" >> $GITHUB_OUTPUT          
           
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           actual: "${{ steps.metadata.outputs.dir_exists }}"
           expected: "0"
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           actual: "${{ steps.metadata.outputs.file_exists }}"
           expected: "0"
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           actual: "${{ steps.metadata.outputs.file_md_exists }}"
           expected: "1"
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           actual: "${{ fromJSON(steps.metadata.outputs.file_json) }}"
           expected: |
             { "stack": "plat-ue2-sandbox", "component": "foobar", "componentPath": "tests/terraform/components/terraform/foobar", "drifted": false, "error": false }
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           actual: "${{ fromJSON(needs.test.outputs.summary) }}"
           expected: ""

--- a/.github/workflows/test-no-changes.yml
+++ b/.github/workflows/test-no-changes.yml
@@ -31,7 +31,7 @@ jobs:
     continue-on-error: true
     needs: [setup]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 
@@ -79,13 +79,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: 'success'
           actual: "${{ needs.test.outputs.result }}"
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: metadata
           pattern: metadata-*
@@ -100,12 +100,12 @@ jobs:
           DIR_EXISTS=$?
           echo "dir_exists=${DIR_EXISTS}" >> $GITHUB_OUTPUT
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           actual: "${{ steps.metadata.outputs.dir_exists }}"
           expected: "1"
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           actual: "${{ fromJSON(needs.test.outputs.summary) }}"
           expected: |

--- a/.github/workflows/test-settings-action-disabled-drift.yml
+++ b/.github/workflows/test-settings-action-disabled-drift.yml
@@ -31,7 +31,7 @@ jobs:
     continue-on-error: true
     needs: [setup]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 
@@ -80,13 +80,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: 'success'
           actual: "${{ needs.test.outputs.result }}"
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: metadata
           pattern: metadata-*
@@ -101,12 +101,12 @@ jobs:
           DIR_EXISTS=$?
           echo "dir_exists=${DIR_EXISTS}" >> $GITHUB_OUTPUT
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           actual: "${{ steps.metadata.outputs.dir_exists }}"
           expected: "1"
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           actual: "${{ fromJSON(needs.test.outputs.summary) }}"
           expected: ""

--- a/.github/workflows/test-settings-action-disabled.yml
+++ b/.github/workflows/test-settings-action-disabled.yml
@@ -31,7 +31,7 @@ jobs:
     continue-on-error: true
     needs: [setup]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 
@@ -79,13 +79,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: 'success'
           actual: "${{ needs.test.outputs.result }}"
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: metadata
           pattern: metadata-*
@@ -100,12 +100,12 @@ jobs:
           DIR_EXISTS=$?
           echo "dir_exists=${DIR_EXISTS}" >> $GITHUB_OUTPUT
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           actual: "${{ steps.metadata.outputs.dir_exists }}"
           expected: "1"
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           actual: "${{ fromJSON(needs.test.outputs.summary) }}"
           expected: ""

--- a/action.yml
+++ b/action.yml
@@ -95,7 +95,7 @@ runs:
   steps:
     - name: Checkout
       if: ${{ inputs.skip-checkout != 'true' }}
-      uses: actions/checkout@v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         ref: ${{ inputs.sha }}
 
@@ -106,7 +106,7 @@ runs:
 
     - name: Install Atmos
       if: ${{ inputs.atmos-version != '' }}
-      uses: cloudposse/github-action-setup-atmos@v2
+      uses: cloudposse/github-action-setup-atmos@60878d48037763f759aedee74e9cc0c2dc88e9ec # v3.5.0
       with:
         atmos-version: ${{ inputs.atmos-version }}
         token: ${{ inputs.token }}
@@ -254,7 +254,7 @@ runs:
         AQUA_LOG_LEVEL: debug
 
     - name: Configure Plan AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
       if: ${{ fromJson(steps.atmos-settings.outputs.settings).aws-region != '' &&
         fromJson(steps.atmos-settings.outputs.settings).aws-region != 'null' &&
         fromJson(steps.atmos-settings.outputs.settings).terraform-plan-role != '' &&
@@ -263,7 +263,7 @@ runs:
         aws-region: ${{ fromJson(steps.atmos-settings.outputs.settings).aws-region }}
         role-to-assume: ${{ fromJson(steps.atmos-settings.outputs.settings).terraform-plan-role }}
         role-session-name: "atmos-terraform-plan-gitops"
-        mask-aws-account-id: "no"
+        mask-aws-account-id: "false"
 
     - name: Set atmos cli base path vars
       if: ${{ fromJson(steps.atmos-settings.outputs.settings).github-actions-enabled || fromJson(steps.atmos-settings.outputs.settings).atmos-pro-enabled }}
@@ -316,7 +316,7 @@ runs:
 
     - name: Cache .terraform
       id: cache
-      uses: actions/cache@v4
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       if: ${{ fromJson(steps.atmos-settings.outputs.settings).github-actions-enabled || fromJson(steps.atmos-settings.outputs.settings).atmos-pro-enabled }}
       with:
         path: |
@@ -457,7 +457,7 @@ runs:
         fi
 
     - name: Configure State AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
       if: ${{ ( fromJson(steps.atmos-settings.outputs.settings).plan-repository-type == 's3' ||
                 fromJson(steps.atmos-settings.outputs.settings).plan-repository-type == ''  ||
                 fromJson(steps.atmos-settings.outputs.settings).plan-repository-type == 'null' ) &&
@@ -470,7 +470,7 @@ runs:
         aws-region: ${{ fromJson(steps.atmos-settings.outputs.settings).aws-region }}
         role-to-assume: ${{ fromJson(steps.atmos-settings.outputs.settings).terraform-state-role }}
         role-session-name: "atmos-terraform-state-gitops"
-        mask-aws-account-id: "no"
+        mask-aws-account-id: "false"
 
     - name: Store New Plan
       if: ${{ steps.atmos-plan.outputs.error == 'false' && inputs.plan-storage == 'true'}}
@@ -625,7 +625,7 @@ runs:
 
     - name: Upload Artifacts
       if: ${{ (fromJson(steps.atmos-settings.outputs.settings).github-actions-enabled || fromJson(steps.atmos-settings.outputs.settings).atmos-pro-enabled) && inputs.drift-detection-mode-enabled == 'true' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         # The name of the artifact needs to be unique for every job run!
         # This name is filtered in cloudposse/github-action-atmos-terraform-drift-detection by the "metadata-*" prefix

--- a/action.yml
+++ b/action.yml
@@ -238,7 +238,7 @@ runs:
         fi
 
     - name: Cache Aqua
-      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/.local/share/aquaproj-aqua
         key: v2-aqua-installer-${{runner.os}}-${{runner.arch}}-${{hashFiles('aqua.yaml')}}


### PR DESCRIPTION
## what

* Bump GitHub Actions references in the workflows and `action.yml` to versions running on the
  Node 24 runtime, SHA-pinned with precise version comments:
  * `actions/checkout@v4` → `@3d3c42e5...` `# v7.0.1`
  * `nick-fields/assert-action@v2` → `@0efd6166...` `# v4.0.1`
  * `actions/download-artifact@v4` → `@3e5f45b2...` `# v8.0.1`
  * `actions/upload-artifact@v4` → `@043fb46d...` `# v7.0.1`
  * `actions/cache@v4` → `@55cc8345...` `# v6.1.0`
  * `cloudposse/github-action-setup-atmos@v2` → `@60878d48...` `# v3.5.0`
  * `aws-actions/configure-aws-credentials@v4` → `@e6de0542...` `# v6.2.3`
* `configure-aws-credentials` v5+ enforces strict boolean input values, so the two
  `mask-aws-account-id: "no"` inputs were rewritten to `"false"`

Supersedes #143
Supersedes #142
Supersedes #141
Supersedes #135
Supersedes #131
Supersedes #110

## why

* GitHub is deprecating the Node 20 runtime; affected workflows emit a deprecation warning and
  are already being force-migrated to Node 24
* SHA pinning with a verified tag comment makes the upgrade deliberate and supply-chain-safe,
  matching the org's direction in cloudposse/.github#261
* Every pinned SHA was verified against its upstream tag

## references

* https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
